### PR TITLE
Bootstrap ARM64 UEFI boot harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/release/

--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ installer entrypoint, installation orchestration, and VM/build/test
 harnesses. It does not own target-system setup, Apple Silicon/Asahi hardware
 configuration, or package adaptations — that's `omarchy-mac`'s job.
 
-## Current milestone: M0
+## M0
 
-M0 proves one thing: a reproducible build produces an ARM64 artifact that
-boots under real AArch64 UEFI to a live userspace and announces a
-deterministic ready signal, entirely under QEMU, with no Apple Silicon
-hardware involved.
+M0 proves that a reproducible ARM64 build crosses the AArch64 UEFI boundary
+under QEMU, reaches Linux userspace, and emits a deterministic readiness
+signal.
 
 ```
 source
@@ -26,107 +25,70 @@ source
   -> "OMARCHY_MAC_ISO_READY" on the serial console
 ```
 
-**M0 does not prove bare-metal Apple Silicon support.** A successful QEMU
-boot says nothing about M1/M2 hardware — that validation belongs to a later
-Asahi-integration milestone. M0 also does not touch disk partitioning,
-bootloaders, target-system installation, or anything Asahi/m1n1/u-boot
-specific; see `omarchy-mac` for all of that.
+M0 does not prove bare-metal Apple Silicon support, and does not touch disk
+partitioning, bootloaders, target-system installation, or anything
+Asahi/m1n1/u-boot specific — see `omarchy-mac` for all of that.
 
-### Why the artifact isn't an ISO
-
-This host has no Docker/Podman/Lima, and upstream's build
-(`docker run archlinux/archlinux ... mkarchiso`) needs one. Building a real
-Arch Linux ARM archiso image is deferred to whichever milestone actually
-needs pacman running inside the live environment. M0's artifact is a plain
-kernel + gzip'd cpio initramfs — Alpine aarch64's `linux-virt` kernel is
-itself a valid UEFI PE32+ application (EFI stub), so QEMU's
-`-kernel`/`-initrd` flags route through the real edk2 UEFI boot manager
-(`QemuKernelLoaderFsDxe` + the standard PE/COFF loader), not a bypass. No ESP
-filesystem, no bootloader, no disk image needed to prove the UEFI boundary.
-
-### Why the live content is Alpine, not Arch Linux ARM
-
-`omarchy-mac` targets Asahi Alarm (Arch Linux ARM), but M0's live environment
-never runs pacman or installs anything — it only needs to reach a live
-userspace and print a marker. Alpine's aarch64 minirootfs is the smallest
-correct content for that. This is a throwaway generic environment, not a
-preview of the eventual installer environment; a later milestone will swap in
-a real Arch Linux ARM rootfs once pacman-driven install work actually starts.
-
-## Supported development environment
+## Requirements
 
 - macOS (Apple Silicon or Intel) or Linux, x86_64 or aarch64
-- [`qemu`](https://www.qemu.org/) on `PATH` (provides both the emulator and,
-  on macOS via Homebrew, the AArch64 UEFI firmware)
+- [`qemu`](https://www.qemu.org/) on `PATH` — on macOS via Homebrew this also
+  provides the AArch64 UEFI firmware
   - macOS: `brew install qemu`
   - Debian/Ubuntu: `apt install qemu-system-arm qemu-efi-aarch64`
   - Arch: `pacman -S qemu-system-aarch64 edk2-armvirt`
-- Everything else (`curl`, `tar`, `cpio`, `gzip`, `shasum`) ships with macOS
-  and virtually every Linux distro already.
-- No root privileges required. No virtual disks are created — M0 boots
-  entirely from RAM.
+- `curl`, `tar`, `cpio`, `gzip`, `shasum` — ship with macOS and virtually
+  every Linux distro already
+- No root privileges and no virtual disks: M0 boots entirely from RAM
 
 Hardware acceleration is used when available (HVF on Apple Silicon, KVM on
 Linux aarch64 hosts with `/dev/kvm`) and falls back to software emulation
-(TCG) otherwise, with a printed warning that boot will be slower.
+(TCG) otherwise.
 
-An Apple Silicon Mac running this is a fast native-aarch64 QEMU *host* for
-development. It is not a claim of bare-metal support for that Mac — see
-the milestone notes above.
-
-## How to build
+## Build
 
 ```
 ./bin/omarchy-mac-iso-make
 ```
 
 Downloads pinned, checksummed upstream artifacts (cached under
-`~/.cache/omarchy-mac-iso/`, so repeat builds are fast and offline), and
-writes `release/omarchy-mac-iso-arm64/{vmlinuz,initramfs.img,BUILD_INFO}`.
+`~/.cache/omarchy-mac-iso/`), and writes
+`release/omarchy-mac-iso-arm64/{vmlinuz,initramfs.img,BUILD_INFO}`.
 
-## How to boot
+## Boot
 
 ```
 ./bin/omarchy-mac-iso-boot
 ```
 
-Prints the exact `qemu-system-aarch64` invocation, then boots interactively
-(`Ctrl-A X` to quit). You should see the UEFI firmware banner, kernel boot
-log, `==> OMARCHY_MAC_ISO_READY`, and a usable shell prompt.
+Boots interactively (`Ctrl-A X` to quit). Expect the UEFI firmware banner,
+kernel boot log, `==> OMARCHY_MAC_ISO_READY`, and a shell prompt.
 
-Pass an explicit artifact directory to boot something other than the default:
-
-```
-./bin/omarchy-mac-iso-boot release/omarchy-mac-iso-arm64
-```
-
-## How to run the tests
+## Test
 
 ```
 ./test/unit    # fast, no network, no VM
 ./test/smoke   # full build + boot + marker detection + teardown
 ```
 
-`test/smoke` output:
+On failure, `test/smoke` prints the tail of the serial console log and
+preserves the run directory for debugging.
 
-```
-==> Building ARM64 image
-==> Booting with AArch64 UEFI
-==> Waiting for live environment
-==> OMARCHY_MAC_ISO_READY
-PASS
-```
+## Architecture / Scope
 
-On failure it prints the tail of the serial console log and preserves the
-run directory for debugging, and exits nonzero.
+- M0's artifact is a kernel + initramfs, not a production ISO — Alpine's
+  `linux-virt` kernel is itself a UEFI EFI-stub PE binary, so QEMU boots it
+  directly without an ESP, bootloader, or disk image.
+- Alpine aarch64 is temporary M0 live content, not the eventual installer
+  distro decision; a later milestone swaps in Arch Linux ARM once
+  pacman-driven install work starts.
+- QEMU's generic `virt` machine + edk2 firmware is a stand-in AArch64 UEFI
+  boundary, not Apple Silicon emulation.
+- `omarchy-mac-iso` owns boot/install orchestration; `omarchy-mac` owns
+  target-system Apple Silicon / Omarchy setup.
 
-## What M0 does NOT prove
+## Non-goals
 
-- Apple Silicon bare-metal boot (any generation)
-- Anything about Asahi's own boot chain (m1n1, u-boot, GRUB) — M0 boots
-  under QEMU's generic `virt` machine and edk2 UEFI firmware, a stand-in
-  hardware-abstraction boundary, not real Apple Silicon firmware
-- Target-disk installation, chroot setup, user creation, or any
-  `omarchy-mac` target-side setup — that's owned entirely by `omarchy-mac`
-- Package management of any kind (no pacman in this image)
+- Package management of any kind — no pacman in this image
 - Disk encryption, production installer UX, or hardware auto-detection
+- chroot setup or user creation — that's `omarchy-mac`'s job

--- a/README.md
+++ b/README.md
@@ -1,0 +1,132 @@
+# Omarchy Mac ISO
+
+Live-boot / installer-environment counterpart to
+[omarchy-mac](https://github.com/omarchy-mac/omarchy-mac), mirroring how
+[omacom-io/omarchy-iso](https://github.com/omacom-io/omarchy-iso) relates to
+upstream Omarchy on x86_64. This repo owns the live boot environment,
+installer entrypoint, installation orchestration, and VM/build/test
+harnesses. It does not own target-system setup, Apple Silicon/Asahi hardware
+configuration, or package adaptations — that's `omarchy-mac`'s job.
+
+## Current milestone: M0
+
+M0 proves one thing: a reproducible build produces an ARM64 artifact that
+boots under real AArch64 UEFI to a live userspace and announces a
+deterministic ready signal, entirely under QEMU, with no Apple Silicon
+hardware involved.
+
+```
+source
+  -> ./bin/omarchy-mac-iso-make
+  -> release/omarchy-mac-iso-arm64/{vmlinuz,initramfs.img}
+  -> ./bin/omarchy-mac-iso-boot
+  -> AArch64 UEFI (edk2)
+  -> Linux kernel + initramfs
+  -> live userspace
+  -> "OMARCHY_MAC_ISO_READY" on the serial console
+```
+
+**M0 does not prove bare-metal Apple Silicon support.** A successful QEMU
+boot says nothing about M1/M2 hardware — that validation belongs to a later
+Asahi-integration milestone. M0 also does not touch disk partitioning,
+bootloaders, target-system installation, or anything Asahi/m1n1/u-boot
+specific; see `omarchy-mac` for all of that.
+
+### Why the artifact isn't an ISO
+
+This host has no Docker/Podman/Lima, and upstream's build
+(`docker run archlinux/archlinux ... mkarchiso`) needs one. Building a real
+Arch Linux ARM archiso image is deferred to whichever milestone actually
+needs pacman running inside the live environment. M0's artifact is a plain
+kernel + gzip'd cpio initramfs — Alpine aarch64's `linux-virt` kernel is
+itself a valid UEFI PE32+ application (EFI stub), so QEMU's
+`-kernel`/`-initrd` flags route through the real edk2 UEFI boot manager
+(`QemuKernelLoaderFsDxe` + the standard PE/COFF loader), not a bypass. No ESP
+filesystem, no bootloader, no disk image needed to prove the UEFI boundary.
+
+### Why the live content is Alpine, not Arch Linux ARM
+
+`omarchy-mac` targets Asahi Alarm (Arch Linux ARM), but M0's live environment
+never runs pacman or installs anything — it only needs to reach a live
+userspace and print a marker. Alpine's aarch64 minirootfs is the smallest
+correct content for that. This is a throwaway generic environment, not a
+preview of the eventual installer environment; a later milestone will swap in
+a real Arch Linux ARM rootfs once pacman-driven install work actually starts.
+
+## Supported development environment
+
+- macOS (Apple Silicon or Intel) or Linux, x86_64 or aarch64
+- [`qemu`](https://www.qemu.org/) on `PATH` (provides both the emulator and,
+  on macOS via Homebrew, the AArch64 UEFI firmware)
+  - macOS: `brew install qemu`
+  - Debian/Ubuntu: `apt install qemu-system-arm qemu-efi-aarch64`
+  - Arch: `pacman -S qemu-system-aarch64 edk2-armvirt`
+- Everything else (`curl`, `tar`, `cpio`, `gzip`, `shasum`) ships with macOS
+  and virtually every Linux distro already.
+- No root privileges required. No virtual disks are created — M0 boots
+  entirely from RAM.
+
+Hardware acceleration is used when available (HVF on Apple Silicon, KVM on
+Linux aarch64 hosts with `/dev/kvm`) and falls back to software emulation
+(TCG) otherwise, with a printed warning that boot will be slower.
+
+An Apple Silicon Mac running this is a fast native-aarch64 QEMU *host* for
+development. It is not a claim of bare-metal support for that Mac — see
+the milestone notes above.
+
+## How to build
+
+```
+./bin/omarchy-mac-iso-make
+```
+
+Downloads pinned, checksummed upstream artifacts (cached under
+`~/.cache/omarchy-mac-iso/`, so repeat builds are fast and offline), and
+writes `release/omarchy-mac-iso-arm64/{vmlinuz,initramfs.img,BUILD_INFO}`.
+
+## How to boot
+
+```
+./bin/omarchy-mac-iso-boot
+```
+
+Prints the exact `qemu-system-aarch64` invocation, then boots interactively
+(`Ctrl-A X` to quit). You should see the UEFI firmware banner, kernel boot
+log, `==> OMARCHY_MAC_ISO_READY`, and a usable shell prompt.
+
+Pass an explicit artifact directory to boot something other than the default:
+
+```
+./bin/omarchy-mac-iso-boot release/omarchy-mac-iso-arm64
+```
+
+## How to run the tests
+
+```
+./test/unit    # fast, no network, no VM
+./test/smoke   # full build + boot + marker detection + teardown
+```
+
+`test/smoke` output:
+
+```
+==> Building ARM64 image
+==> Booting with AArch64 UEFI
+==> Waiting for live environment
+==> OMARCHY_MAC_ISO_READY
+PASS
+```
+
+On failure it prints the tail of the serial console log and preserves the
+run directory for debugging, and exits nonzero.
+
+## What M0 does NOT prove
+
+- Apple Silicon bare-metal boot (any generation)
+- Anything about Asahi's own boot chain (m1n1, u-boot, GRUB) — M0 boots
+  under QEMU's generic `virt` machine and edk2 UEFI firmware, a stand-in
+  hardware-abstraction boundary, not real Apple Silicon firmware
+- Target-disk installation, chroot setup, user creation, or any
+  `omarchy-mac` target-side setup — that's owned entirely by `omarchy-mac`
+- Package management of any kind (no pacman in this image)
+- Disk encryption, production installer UX, or hardware auto-detection

--- a/bin/omarchy-mac-iso-boot
+++ b/bin/omarchy-mac-iso-boot
@@ -1,16 +1,4 @@
 #!/bin/bash
-# Boots an omarchy-mac-iso M0 boot artifact under QEMU AArch64 UEFI.
-#
-# Usage:
-#   omarchy-mac-iso-boot [artifact-dir]              interactive (default)
-#   omarchy-mac-iso-boot [artifact-dir] --headless   for scripted use (test/smoke)
-#
-# Interactive mode attaches your terminal to the guest console and blocks
-# until you quit QEMU (Ctrl-A X, or a guest poweroff). Headless mode
-# daemonizes QEMU, prints one line on stdout — a temp directory containing
-# serial.log and qemu.pid — and returns immediately; the caller is
-# responsible for tearing the VM down (kill "$(cat <dir>/qemu.pid)") and
-# removing the directory when done.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/bin/omarchy-mac-iso-boot
+++ b/bin/omarchy-mac-iso-boot
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Boots an omarchy-mac-iso M0 boot artifact under QEMU AArch64 UEFI.
+#
+# Usage:
+#   omarchy-mac-iso-boot [artifact-dir]              interactive (default)
+#   omarchy-mac-iso-boot [artifact-dir] --headless   for scripted use (test/smoke)
+#
+# Interactive mode attaches your terminal to the guest console and blocks
+# until you quit QEMU (Ctrl-A X, or a guest poweroff). Headless mode
+# daemonizes QEMU, prints one line on stdout — a temp directory containing
+# serial.log and qemu.pid — and returns immediately; the caller is
+# responsible for tearing the VM down (kill "$(cat <dir>/qemu.pid)") and
+# removing the directory when done.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log() { printf '==> %s\n' "$*" >&2; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+headless=0
+artifact_dir=""
+while (( $# > 0 )); do
+    case "$1" in
+        --headless) headless=1; shift ;;
+        -h|--help)
+            cat <<'EOF'
+Usage: omarchy-mac-iso-boot [artifact-dir] [--headless]
+
+Boots an omarchy-mac-iso M0 boot artifact under QEMU AArch64 UEFI.
+artifact-dir defaults to release/omarchy-mac-iso-arm64.
+
+Interactive mode (default) attaches your terminal to the guest console;
+quit with Ctrl-A X or a guest poweroff.
+
+--headless daemonizes QEMU and prints one line: a temp directory
+containing serial.log and qemu.pid. The caller tears the VM down.
+EOF
+            exit 0
+            ;;
+        *)
+            [[ -z "${artifact_dir}" ]] || fail "unexpected argument: $1"
+            artifact_dir="$1"
+            shift
+            ;;
+    esac
+done
+: "${artifact_dir:=${repo_root}/release/omarchy-mac-iso-arm64}"
+
+vmlinuz="${artifact_dir}/vmlinuz"
+initramfs="${artifact_dir}/initramfs.img"
+[[ -f "${vmlinuz}" && -f "${initramfs}" ]] \
+    || fail "no boot artifact at ${artifact_dir} (run bin/omarchy-mac-iso-make first)"
+
+command -v qemu-system-aarch64 >/dev/null 2>&1 \
+    || fail "qemu-system-aarch64 not found on PATH (macOS: brew install qemu; Debian/Ubuntu: apt install qemu-system-arm; Arch: pacman -S qemu-system-aarch64)"
+
+find_firmware() {
+    local code vars
+    if command -v brew >/dev/null 2>&1; then
+        local qemu_share
+        qemu_share="$(brew --prefix qemu 2>/dev/null || true)/share/qemu"
+        code="${qemu_share}/edk2-aarch64-code.fd"
+        vars="${qemu_share}/edk2-arm-vars.fd"
+        if [[ -f "${code}" && -f "${vars}" ]]; then
+            printf '%s\n%s\n' "${code}" "${vars}"
+            return 0
+        fi
+    fi
+    local candidates=(
+        "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd:/usr/share/edk2-armvirt/aarch64/QEMU_VARS.fd"
+        "/usr/share/AAVMF/AAVMF_CODE.fd:/usr/share/AAVMF/AAVMF_VARS.fd"
+        "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd:/usr/share/qemu-efi-aarch64/QEMU_VARS.fd"
+    )
+    local pair
+    for pair in "${candidates[@]}"; do
+        code="${pair%%:*}"
+        vars="${pair##*:}"
+        if [[ -f "${code}" && -f "${vars}" ]]; then
+            printf '%s\n%s\n' "${code}" "${vars}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+firmware="$(find_firmware)" || fail "no AArch64 UEFI firmware found (macOS: brew install qemu bundles it; Debian/Ubuntu: apt install qemu-efi-aarch64; Arch: pacman -S edk2-armvirt)"
+code_fd="$(sed -n '1p' <<<"${firmware}")"
+vars_fd_src="$(sed -n '2p' <<<"${firmware}")"
+
+accel_args=()
+host_os="$(uname -s)"
+host_arch="$(uname -m)"
+if [[ "${host_os}" == "Darwin" && "${host_arch}" == "arm64" ]]; then
+    accel_args=(-accel hvf -cpu host)
+elif [[ "${host_os}" == "Linux" && "${host_arch}" == "aarch64" && -w /dev/kvm ]]; then
+    accel_args=(-accel kvm -cpu host)
+else
+    log "no native acceleration available on ${host_os}/${host_arch}; falling back to software emulation (tcg) — boot will be noticeably slower"
+    accel_args=(-accel tcg -cpu max)
+fi
+
+run_dir="$(mktemp -d "${TMPDIR:-/tmp}/omarchy-mac-iso-boot.XXXXXX")"
+vars_fd="${run_dir}/vars.fd"
+cp "${vars_fd_src}" "${vars_fd}"
+
+qemu_args=(
+    -machine virt
+    "${accel_args[@]}"
+    -m 512
+    -smp 2
+    -kernel "${vmlinuz}"
+    -initrd "${initramfs}"
+    -append "console=ttyAMA0"
+    -drive "if=pflash,format=raw,readonly=on,file=${code_fd}"
+    -drive "if=pflash,format=raw,file=${vars_fd}"
+    -nic none
+)
+
+if (( headless )); then
+    serial_log="${run_dir}/serial.log"
+    pidfile="${run_dir}/qemu.pid"
+    log "qemu-system-aarch64 ${qemu_args[*]} -serial file:${serial_log} -display none -daemonize -pidfile ${pidfile}"
+    qemu-system-aarch64 "${qemu_args[@]}" \
+        -serial "file:${serial_log}" \
+        -display none \
+        -daemonize \
+        -pidfile "${pidfile}"
+    printf '%s\n' "${run_dir}"
+else
+    trap 'rm -rf "${run_dir}"' EXIT
+    log "qemu-system-aarch64 ${qemu_args[*]} -serial mon:stdio -display none"
+    log "Ctrl-A X to quit"
+    qemu-system-aarch64 "${qemu_args[@]}" -serial mon:stdio -display none
+fi

--- a/bin/omarchy-mac-iso-make
+++ b/bin/omarchy-mac-iso-make
@@ -1,10 +1,4 @@
 #!/bin/bash
-# Builds the M0 ARM64 boot artifact: a kernel + initramfs bundle that boots
-# under AArch64 UEFI (see README.md for why this isn't an .iso yet).
-#
-# Usage: omarchy-mac-iso-make
-#
-# Output: release/omarchy-mac-iso-arm64/{vmlinuz,initramfs.img,BUILD_INFO}
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/bin/omarchy-mac-iso-make
+++ b/bin/omarchy-mac-iso-make
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Builds the M0 ARM64 boot artifact: a kernel + initramfs bundle that boots
+# under AArch64 UEFI (see README.md for why this isn't an .iso yet).
+#
+# Usage: omarchy-mac-iso-make
+#
+# Output: release/omarchy-mac-iso-arm64/{vmlinuz,initramfs.img,BUILD_INFO}
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+builder_dir="${repo_root}/builder"
+artifact_name="omarchy-mac-iso-arm64"
+out_dir="${repo_root}/release/${artifact_name}"
+
+log() { printf '==> %s\n' "$*"; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+check_deps() {
+    local missing=()
+    local cmd
+    for cmd in curl tar cpio gzip shasum install find; do
+        command -v "${cmd}" >/dev/null 2>&1 || missing+=("${cmd}")
+    done
+    if (( ${#missing[@]} > 0 )); then
+        fail "missing required tools: ${missing[*]} (these ship with macOS and most Linux distros; install via your package manager)"
+    fi
+}
+
+usage() {
+    cat <<'EOF'
+Usage: omarchy-mac-iso-make
+
+Builds the M0 ARM64 boot artifact (kernel + initramfs, not an ISO — see
+README.md) into release/omarchy-mac-iso-arm64/.
+EOF
+}
+
+main() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+        usage
+        exit 0
+    fi
+
+    log "Checking build dependencies"
+    check_deps
+
+    log "Fetching pinned upstream artifacts"
+    local fetched minirootfs kernel_apk
+    fetched="$("${builder_dir}/fetch-upstream.sh")"
+    minirootfs="$(sed -n '1p' <<<"${fetched}")"
+    kernel_apk="$(sed -n '2p' <<<"${fetched}")"
+
+    log "Building live root filesystem and initramfs"
+    rm -rf "${out_dir}"
+    "${builder_dir}/build-initramfs.sh" "${minirootfs}" "${kernel_apk}" "${out_dir}"
+
+    local git_ref
+    git_ref="$(git -C "${repo_root}" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+    cat > "${out_dir}/BUILD_INFO" <<EOF
+artifact: ${artifact_name}
+built_from_ref: ${git_ref}
+source: $(basename "${minirootfs}"), $(basename "${kernel_apk}")
+contract: kernel + gzip'd newc cpio initramfs, boots under AArch64 UEFI via
+  qemu-system-aarch64 -machine virt -kernel vmlinuz -initrd initramfs.img
+  (see README.md — this is not an ISO)
+EOF
+
+    log "Writing ${out_dir#"${repo_root}"/}/{vmlinuz,initramfs.img}"
+    log "Build complete"
+}
+
+main "$@"

--- a/builder/build-initramfs.sh
+++ b/builder/build-initramfs.sh
@@ -37,7 +37,7 @@ install -m 755 "${script_dir}/../configs/initramfs/init" "${stage_dir}/init"
 
 log "packing initramfs"
 mkdir -p "${out_dir}"
-( cd "${stage_dir}" && find . -print0 | cpio --null -o -H newc 2>/dev/null ) \
+( cd "${stage_dir}" && find . -print0 | cpio --null -o -H newc ) \
     | gzip -9 > "${out_dir}/initramfs.img"
 
 cp "${kernel_stage}/boot/vmlinuz-virt" "${out_dir}/vmlinuz"

--- a/builder/build-initramfs.sh
+++ b/builder/build-initramfs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Assembles the M0 boot artifact from the cached, checksummed Alpine
+# minirootfs + kernel package: extracts a userspace, installs our own
+# /init as PID 1, packs it as a gzip'd newc cpio initramfs, and stages the
+# kernel alongside it. Takes the two paths printed by fetch-upstream.sh and
+# an output directory.
+#
+# Usage: build-initramfs.sh <minirootfs.tar.gz> <linux-virt.apk> <out-dir>
+set -euo pipefail
+
+minirootfs="$1"
+kernel_apk="$2"
+out_dir="$3"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log() { printf '==> %s\n' "$*" >&2; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+stage_dir="${work_dir}/root"
+mkdir -p "${stage_dir}"
+
+log "extracting Alpine userspace"
+tar -xzf "${minirootfs}" -C "${stage_dir}"
+
+log "extracting kernel from linux-virt package"
+kernel_stage="${work_dir}/kernel"
+mkdir -p "${kernel_stage}"
+tar -xzf "${kernel_apk}" -C "${kernel_stage}" boot/vmlinuz-virt
+[[ -f "${kernel_stage}/boot/vmlinuz-virt" ]] || fail "linux-virt package did not contain boot/vmlinuz-virt"
+
+log "installing init"
+install -m 755 "${script_dir}/../configs/initramfs/init" "${stage_dir}/init"
+
+log "packing initramfs"
+mkdir -p "${out_dir}"
+( cd "${stage_dir}" && find . -print0 | cpio --null -o -H newc 2>/dev/null ) \
+    | gzip -9 > "${out_dir}/initramfs.img"
+
+cp "${kernel_stage}/boot/vmlinuz-virt" "${out_dir}/vmlinuz"
+
+log "staged $(du -h "${out_dir}/vmlinuz" | cut -f1) kernel + $(du -h "${out_dir}/initramfs.img" | cut -f1) initramfs"

--- a/builder/build-initramfs.sh
+++ b/builder/build-initramfs.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
-# Assembles the M0 boot artifact from the cached, checksummed Alpine
-# minirootfs + kernel package: extracts a userspace, installs our own
-# /init as PID 1, packs it as a gzip'd newc cpio initramfs, and stages the
-# kernel alongside it. Takes the two paths printed by fetch-upstream.sh and
-# an output directory.
-#
 # Usage: build-initramfs.sh <minirootfs.tar.gz> <linux-virt.apk> <out-dir>
 set -euo pipefail
 

--- a/builder/fetch-upstream.sh
+++ b/builder/fetch-upstream.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-# Downloads the pinned Alpine minirootfs and kernel package into a local
-# cache, verifying sha256 on every use (cache hit or miss). Prints the two
-# cached file paths on stdout, one per line, for the caller to consume:
-#   <minirootfs tar.gz path>
-#   <kernel apk path>
+# Prints minirootfs and kernel cache paths, one per line.
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/builder/fetch-upstream.sh
+++ b/builder/fetch-upstream.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Downloads the pinned Alpine minirootfs and kernel package into a local
+# cache, verifying sha256 on every use (cache hit or miss). Prints the two
+# cached file paths on stdout, one per line, for the caller to consume:
+#   <minirootfs tar.gz path>
+#   <kernel apk path>
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/versions.env"
+
+cache_dir="${OMARCHY_MAC_ISO_CACHE:-${HOME}/.cache/omarchy-mac-iso}"
+mkdir -p "${cache_dir}"
+
+log() { printf '==> %s\n' "$*" >&2; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+verify_sha256() {
+    local path="$1" expected="$2"
+    local actual
+    actual="$(shasum -a 256 "${path}" | cut -d' ' -f1)"
+    if [[ "${actual}" != "${expected}" ]]; then
+        fail "checksum mismatch for $(basename "${path}"): expected ${expected}, got ${actual} (delete ${path} and retry, or the pin in versions.env is stale)"
+    fi
+}
+
+fetch_pinned() {
+    local url="$1" sha256="$2" dest="$3"
+
+    if [[ -f "${dest}" ]]; then
+        if actual="$(shasum -a 256 "${dest}" | cut -d' ' -f1)" && [[ "${actual}" == "${sha256}" ]]; then
+            log "using cached $(basename "${dest}")"
+            return 0
+        fi
+        log "cached $(basename "${dest}") failed checksum, re-downloading"
+        rm -f "${dest}"
+    fi
+
+    log "downloading $(basename "${dest}")"
+    local tmp
+    tmp="$(mktemp "${dest}.XXXXXX")"
+    if ! curl -fSL --progress-bar "${url}" -o "${tmp}"; then
+        rm -f "${tmp}"
+        fail "download failed: ${url}"
+    fi
+    verify_sha256 "${tmp}" "${sha256}"
+    mv "${tmp}" "${dest}"
+}
+
+minirootfs_dest="${cache_dir}/alpine-minirootfs-${ALPINE_VERSION}-${ALPINE_ARCH}.tar.gz"
+kernel_dest="${cache_dir}/linux-virt-${KERNEL_PKG_VERSION}.apk"
+
+fetch_pinned "${MINIROOTFS_URL}" "${MINIROOTFS_SHA256}" "${minirootfs_dest}"
+fetch_pinned "${KERNEL_PKG_URL}" "${KERNEL_PKG_SHA256}" "${kernel_dest}"
+
+printf '%s\n%s\n' "${minirootfs_dest}" "${kernel_dest}"

--- a/builder/versions.env
+++ b/builder/versions.env
@@ -1,0 +1,21 @@
+# Pinned upstream artifacts for the M0 live environment.
+#
+# The M0 boot content is a generic Alpine aarch64 userspace, not Arch Linux
+# ARM / Asahi Alarm. It exists only to prove the build -> UEFI boot -> live
+# userspace -> ready-marker pipeline; omarchy-mac's actual target OS is
+# unrelated to this choice. See README.md for the full rationale.
+#
+# Bump ALPINE_VERSION deliberately, then update every URL/SHA256 pair below
+# together (re-derive checksums from Alpine's published sidecars) so the
+# build stays reproducible and byte-pinned rather than "latest".
+
+ALPINE_VERSION=3.24.1
+ALPINE_ARCH=aarch64
+ALPINE_MIRROR=https://dl-cdn.alpinelinux.org/alpine
+
+MINIROOTFS_URL=${ALPINE_MIRROR}/v3.24/releases/${ALPINE_ARCH}/alpine-minirootfs-${ALPINE_VERSION}-${ALPINE_ARCH}.tar.gz
+MINIROOTFS_SHA256=f55a90f69052c5bd6f92cb09a8f47065970830b194c917a006fb94028e721259
+
+KERNEL_PKG_VERSION=6.18.44-r0
+KERNEL_PKG_URL=${ALPINE_MIRROR}/v3.24/main/${ALPINE_ARCH}/linux-virt-${KERNEL_PKG_VERSION}.apk
+KERNEL_PKG_SHA256=023c34a7e1255840074bc396cf5cd0a50cf697c7f3a94477ac17563eb8631f1a

--- a/builder/versions.env
+++ b/builder/versions.env
@@ -1,13 +1,4 @@
-# Pinned upstream artifacts for the M0 live environment.
-#
-# The M0 boot content is a generic Alpine aarch64 userspace, not Arch Linux
-# ARM / Asahi Alarm. It exists only to prove the build -> UEFI boot -> live
-# userspace -> ready-marker pipeline; omarchy-mac's actual target OS is
-# unrelated to this choice. See README.md for the full rationale.
-#
-# Bump ALPINE_VERSION deliberately, then update every URL/SHA256 pair below
-# together (re-derive checksums from Alpine's published sidecars) so the
-# build stays reproducible and byte-pinned rather than "latest".
+# Pinned M0 boot-environment inputs. Update versions and checksums together.
 
 ALPINE_VERSION=3.24.1
 ALPINE_ARCH=aarch64

--- a/configs/initramfs/init
+++ b/configs/initramfs/init
@@ -1,0 +1,22 @@
+#!/bin/sh
+# PID 1 of the M0 live environment. Runs from the initramfs root under
+# busybox ash (Alpine's /bin/sh). Mounts the baseline pseudo-filesystems,
+# announces the deterministic ready marker on the console, then hands off
+# to an interactive shell so a human attached to the serial console has
+# something to look at. test/smoke does not wait for anything past the
+# marker line.
+set -e
+
+mount -t proc none /proc
+mount -t sysfs none /sys
+mount -t devtmpfs none /dev
+
+echo "==> OMARCHY_MAC_ISO_READY" > /dev/console
+
+# Best-effort interactive shell for a human attached to a real console. Not
+# exec'd: if the console has no readable input (e.g. test/smoke's file-backed
+# serial log), the shell exits immediately on EOF, and PID 1 must survive
+# that or the kernel panics with "Attempted to kill init!".
+setsid sh -c 'exec sh </dev/console >/dev/console 2>&1' || true
+
+while true; do sleep 3600; done

--- a/configs/initramfs/init
+++ b/configs/initramfs/init
@@ -1,10 +1,4 @@
 #!/bin/sh
-# PID 1 of the M0 live environment. Runs from the initramfs root under
-# busybox ash (Alpine's /bin/sh). Mounts the baseline pseudo-filesystems,
-# announces the deterministic ready marker on the console, then hands off
-# to an interactive shell so a human attached to the serial console has
-# something to look at. test/smoke does not wait for anything past the
-# marker line.
 set -e
 
 mount -t proc none /proc

--- a/test/smoke
+++ b/test/smoke
@@ -1,7 +1,4 @@
 #!/bin/bash
-# Full pipeline smoke test: build, boot under QEMU AArch64 UEFI, wait for
-# the deterministic ready marker on the serial console, tear down.
-#
 # Usage: test/smoke [timeout-seconds]   (default 60)
 set -euo pipefail
 

--- a/test/smoke
+++ b/test/smoke
@@ -30,6 +30,7 @@ teardown() {
     kill -0 "${pid}" 2>/dev/null && kill -9 "${pid}" 2>/dev/null
     return 0
 }
+trap teardown EXIT
 
 log "Waiting for live environment"
 found=0

--- a/test/smoke
+++ b/test/smoke
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Full pipeline smoke test: build, boot under QEMU AArch64 UEFI, wait for
+# the deterministic ready marker on the serial console, tear down.
+#
+# Usage: test/smoke [timeout-seconds]   (default 60)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+timeout="${1:-60}"
+marker="OMARCHY_MAC_ISO_READY"
+
+log() { printf '==> %s\n' "$*"; }
+
+log "Building ARM64 image"
+"${repo_root}/bin/omarchy-mac-iso-make"
+
+log "Booting with AArch64 UEFI"
+run_dir="$("${repo_root}/bin/omarchy-mac-iso-boot" --headless)"
+serial_log="${run_dir}/serial.log"
+pidfile="${run_dir}/qemu.pid"
+
+teardown() {
+    [[ -f "${pidfile}" ]] || return 0
+    local pid
+    pid="$(cat "${pidfile}" 2>/dev/null || true)"
+    [[ -n "${pid}" ]] || return 0
+    kill -0 "${pid}" 2>/dev/null || return 0
+    kill "${pid}" 2>/dev/null || true
+    sleep 1
+    kill -0 "${pid}" 2>/dev/null && kill -9 "${pid}" 2>/dev/null
+    return 0
+}
+
+log "Waiting for live environment"
+found=0
+elapsed=0
+while (( elapsed < timeout )); do
+    if [[ -f "${serial_log}" ]] && grep -q "${marker}" "${serial_log}" 2>/dev/null; then
+        found=1
+        break
+    fi
+    sleep 1
+    elapsed=$(( elapsed + 1 ))
+done
+
+teardown
+
+if (( found )); then
+    log "${marker}"
+    rm -rf "${run_dir}"
+    echo "PASS"
+    exit 0
+fi
+
+printf 'error: timed out after %ss waiting for %s\n' "${timeout}" "${marker}" >&2
+printf 'error: serial log (%s):\n' "${serial_log}" >&2
+tail -n 40 "${serial_log}" >&2 2>/dev/null || echo "(no serial log written)" >&2
+printf 'error: run directory preserved for debugging: %s\n' "${run_dir}" >&2
+echo "FAIL"
+exit 1

--- a/test/unit
+++ b/test/unit
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Fast, no-network, no-VM sanity checks. Run before test/smoke.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+failures=0
+
+check() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        printf 'ok   - %s\n' "${desc}"
+    else
+        printf 'FAIL - %s\n' "${desc}"
+        failures=$(( failures + 1 ))
+    fi
+}
+
+for f in "${repo_root}"/bin/omarchy-mac-iso-* "${repo_root}"/builder/*.sh; do
+    check "bash -n $(basename "${f}")" bash -n "${f}"
+done
+
+check "sh -n init" sh -n "${repo_root}/configs/initramfs/init"
+
+if command -v shellcheck >/dev/null 2>&1; then
+    for f in "${repo_root}"/bin/omarchy-mac-iso-* "${repo_root}"/builder/*.sh; do
+        check "shellcheck $(basename "${f}")" shellcheck "${f}"
+    done
+else
+    echo "skip - shellcheck not installed"
+fi
+
+# shellcheck source=../builder/versions.env
+source "${repo_root}/builder/versions.env"
+check "MINIROOTFS_SHA256 is 64 hex chars" bash -c "[[ '${MINIROOTFS_SHA256}' =~ ^[0-9a-f]{64}\$ ]]"
+check "KERNEL_PKG_SHA256 is 64 hex chars" bash -c "[[ '${KERNEL_PKG_SHA256}' =~ ^[0-9a-f]{64}\$ ]]"
+
+check "omarchy-mac-iso-make --help works offline" "${repo_root}/bin/omarchy-mac-iso-make" --help
+check "omarchy-mac-iso-boot --help works offline" "${repo_root}/bin/omarchy-mac-iso-boot" --help
+
+if (( failures > 0 )); then
+    echo "${failures} failure(s)"
+    exit 1
+fi
+echo "all unit checks passed"

--- a/test/unit
+++ b/test/unit
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Fast, no-network, no-VM sanity checks. Run before test/smoke.
 set -uo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary

Adds the first ARM64 boot harness for `omarchy-mac-iso`.

This establishes a reproducible development path from:

`build → AArch64 UEFI → Linux userspace → readiness signal`

under QEMU, without requiring M1/M2 hardware.

## Design

- Boots an ARM64 kernel + initramfs under QEMU with EDK2 UEFI.
- Emits `OMARCHY_MAC_ISO_READY` on the serial console once userspace is alive.
- Adds a deterministic smoke test around signal.
- Keeps the live environment intentionally minimal; the current Alpine rootfs is only a boot-harness dependency, not a distribution choice for the eventual installer.
- Keeps target-side Apple Silicon and Omarchy setup in`omarchy-mac`. This repository remains responsible for the boot/install environment and orchestration.

## Validation

- `./test/unit` — 13/13 pass
- `./test/smoke` — passing
- Verified failure behavior for:
  - missing QEMU
  - missing boot artifact
  - missing readiness marker / timeout

The smoke test boots the image through EDK2, observes the readiness marker and tears the VM down cleanly.

## Out of scope

- Asahi bare-metal integration
- M1/M2 hardware validation
- target-disk installation
- encryption
- user creation
- production installer UI

## Next

Add the installer entrypoint and basic `configuration/state-machine` flow on top of this harness.