### PR TITLE
USB live image: linux-asahi, dwc3-apple, overlay + switch_root

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,27 @@ on Linux aarch64 with `/dev/kvm`) and falls back to TCG otherwise.
 
 On smoke failure, the serial log is printed and the run directory is
 kept for debugging.
+
+## USB image (Apple Silicon host)
+
+On a machine that already runs `linux-asahi`:
+
+```
+./bin/omarchy-mac-iso-make --usb
+```
+
+Writes `release/omarchy-mac-iso-usb/omarchy-mac-usb.img` — GPT, one FAT32
+ESP labelled `OMARCHYISO`, standalone GRUB, this host's `linux-asahi`,
+an initramfs with `dwc3-apple`, and a tiny `root.img`. No root required.
+
+Flash (destroys the target stick):
+
+```
+sudo dd if=release/omarchy-mac-iso-usb/omarchy-mac-usb.img of=/dev/sdX bs=4M status=progress conv=fsync
+```
+
+Boot via U-Boot (`usb start`, `bootflow scan -l usb`, `bootflow select 0`,
+`bootflow boot` if NVMe already has Linux). A fresh UEFI-only Mac should
+take USB automatically. Success prints `OMARCHY_MAC_USB_READY` and hangs
+in the initramfs with the overlay at `/new_root`. This is not yet a full
+Omarchy desktop or installer.

--- a/README.md
+++ b/README.md
@@ -84,8 +84,23 @@ Flash (destroys the target stick):
 sudo dd if=release/omarchy-mac-iso-usb/omarchy-mac-usb.img of=/dev/sdX bs=4M status=progress conv=fsync
 ```
 
-Boot via U-Boot (`usb start`, `bootflow scan -l usb`, `bootflow select 0`,
-`bootflow boot` if NVMe already has Linux). A fresh UEFI-only Mac should
-take USB automatically. Success prints `OMARCHY_MAC_USB_READY` and hangs
-in the initramfs with the overlay at `/new_root`. This is not yet a full
-Omarchy desktop or installer.
+**Shutdown, then power on** — a warm reboot often leaves Type-C/PD
+unenumerated in U-Boot (`0 Storage Device(s) found`). After a cold start,
+interrupt U-Boot (~1s) if NVMe already has Linux, and load the stick's
+GRUB explicitly (do not `saveenv`):
+
+```
+load usb 0:1 ${kernel_addr_r} /EFI/BOOT/BOOTAA64.EFI
+bootefi ${kernel_addr_r} ${fdtcontroladdr}
+```
+
+`bootflow select` of the USB row can still load NVMe's
+`/EFI/BOOT/BOOTAA64.EFI` (same path on both ESPs). `bootcmd_usb0` is not
+defined on this U-Boot. A fresh UEFI-only Mac has no NVMe EFI payload, so
+the stick should win automatically after a cold start.
+
+USB GRUB prints `OMARCHY USB GRUB (not the NVMe ESP)` and has one entry.
+Omarchy Linux / Advanced options means you are on NVMe.
+
+Success prints `OMARCHY_MAC_USB_READY` and hangs in the initramfs with the
+overlay at `/new_root`. This is not yet a full Omarchy desktop or installer.

--- a/README.md
+++ b/README.md
@@ -102,5 +102,5 @@ the stick should win automatically after a cold start.
 USB GRUB prints `OMARCHY USB GRUB (not the NVMe ESP)` and has one entry.
 Omarchy Linux / Advanced options means you are on NVMe.
 
-Success prints `OMARCHY_MAC_USB_READY` and hangs in the initramfs with the
-overlay at `/new_root`. This is not yet a full Omarchy desktop or installer.
+Success prints `OMARCHY_MAC_USB_READY`, then `OMARCHY_MAC_USB_USERSPACE pid=1`,
+and hangs. This is not yet a full Omarchy desktop or installer.

--- a/bin/omarchy-mac-iso-make
+++ b/bin/omarchy-mac-iso-make
@@ -22,17 +22,42 @@ check_deps() {
 
 usage() {
     cat <<'EOF'
-Usage: omarchy-mac-iso-make
+Usage: omarchy-mac-iso-make [--usb]
 
-Builds the M0 ARM64 boot artifact (kernel + initramfs, not an ISO — see
-README.md) into release/omarchy-mac-iso-arm64/.
+Default: M0 QEMU artifact (Alpine linux-virt kernel + initramfs) into
+release/omarchy-mac-iso-arm64/. Does not boot a Mac.
+
+--usb: native Apple Silicon GPT image (linux-asahi, GRUB ESP, root.img)
+into release/omarchy-mac-iso-usb/. Requires linux-asahi on the host.
 EOF
 }
 
 main() {
-    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-        usage
-        exit 0
+    local mode="qemu"
+    case "${1:-}" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --usb)
+            mode="usb"
+            shift
+            [[ "${1:-}" == "" ]] || fail "unexpected argument: $1"
+            ;;
+        "")
+            ;;
+        *)
+            fail "unexpected argument: $1"
+            ;;
+    esac
+
+    if [[ "${mode}" == "usb" ]]; then
+        log "Checking USB-image build dependencies"
+        local usb_dir="${repo_root}/release/omarchy-mac-iso-usb"
+        rm -rf "${usb_dir}"
+        "${builder_dir}/build-usb-image.sh" "${usb_dir}"
+        log "Build complete"
+        return 0
     fi
 
     log "Checking build dependencies"

--- a/builder/build-usb-image.sh
+++ b/builder/build-usb-image.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Usage: build-usb-image.sh <out-dir>
+# Native Apple Silicon build: GPT disk image with a FAT ESP (GRUB, linux-asahi,
+# live initramfs, root.img). Unprivileged: udisks loop-mounts a FAT file.
+set -euo pipefail
+
+out_dir="$1"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+kver="$(uname -r)"
+
+log() { printf '==> %s\n' "$*" >&2; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+[[ $(uname -m) == aarch64 ]] || fail "--usb needs an aarch64 host (this builds linux-asahi into the image)"
+[[ -f /boot/vmlinuz-linux-asahi ]] || fail "no /boot/vmlinuz-linux-asahi — install linux-asahi"
+command -v mkinitcpio >/dev/null || fail "mkinitcpio not found"
+command -v grub-mkstandalone >/dev/null || fail "grub-mkstandalone not found (pacman -S grub)"
+command -v mkfs.vfat >/dev/null || fail "mkfs.vfat not found (pacman -S dosfstools)"
+command -v parted >/dev/null || fail "parted not found"
+command -v udisksctl >/dev/null || fail "udisksctl not found"
+
+work="$(mktemp -d)"
+loop_dev=""
+cleanup() {
+  if [[ -n $loop_dev ]]; then
+    udisksctl unmount -b "$loop_dev" --no-user-interaction >/dev/null 2>&1 || true
+    udisksctl loop-delete -b "$loop_dev" --no-user-interaction >/dev/null 2>&1 || true
+  fi
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+mkdir -p "$work" "$out_dir"
+
+log "Building root.img"
+"$repo_root/builder/build-usb-rootimg.sh" "$work/root.img"
+
+log "Building live initramfs (linux-asahi $kver, dwc3-apple)"
+mkinitcpio -n \
+  -c "$repo_root/configs/usb-initcpio/mkinitcpio.conf" \
+  -D /usr/lib/initcpio \
+  -D "$repo_root/configs/usb-initcpio" \
+  -k "$kver" \
+  -g "$work/initramfs-omarchy-usb.img"
+
+log "Building standalone GRUB"
+grub-mkstandalone -O arm64-efi \
+  --fonts="" --locales="" --themes="" \
+  --install-modules="linux fat ext2 part_gpt search search_label search_fs_uuid echo normal configfile gzio reboot sleep" \
+  --modules="part_gpt fat search search_label linux echo normal" \
+  -o "$work/BOOTAA64.EFI" \
+  "boot/grub/grub.cfg=$repo_root/configs/usb/grub.cfg"
+
+# 512 MiB FAT ESP, GPT wrapper with 1 MiB headroom.
+fat_kb=$((512 * 1024))
+fat_bytes=$((fat_kb * 1024))
+disk_bytes=$((fat_bytes + 2 * 1024 * 1024))
+
+log "Formatting ESP"
+mkfs.vfat -F 32 -n OMARCHYISO -C "$work/esp.fat" "$fat_kb" >/dev/null
+
+log "Populating ESP"
+map_out="$(udisksctl loop-setup -f "$work/esp.fat" --no-user-interaction)"
+loop_dev="$(printf '%s\n' "$map_out" | grep -oE '/dev/loop[0-9]+')"
+[[ -n $loop_dev ]] || fail "udisksctl loop-setup did not print a loop device"
+
+# udisks often auto-mounts; wait for it
+mnt=""
+for _ in $(seq 1 20); do
+  mnt="$(findmnt -n -o TARGET "$loop_dev" 2>/dev/null || true)"
+  [[ -n $mnt ]] && break
+  sleep 0.2
+done
+if [[ -z $mnt ]]; then
+  mount_out="$(udisksctl mount -b "$loop_dev" --no-user-interaction)"
+  mnt="$(printf '%s\n' "$mount_out" | awk '{print $NF}' | tr -d '.')"
+fi
+[[ -d $mnt ]] || fail "could not mount ESP FAT image"
+
+mkdir -p "$mnt/EFI/BOOT" "$mnt/grub"
+cp "$work/BOOTAA64.EFI" "$mnt/EFI/BOOT/BOOTAA64.EFI"
+cp "$repo_root/configs/usb/grub.cfg" "$mnt/grub/grub.cfg"
+cp /boot/vmlinuz-linux-asahi "$mnt/vmlinuz-linux-asahi"
+cp "$work/initramfs-omarchy-usb.img" "$mnt/initramfs-omarchy-usb.img"
+cp "$work/root.img" "$mnt/root.img"
+sync
+
+udisksctl unmount -b "$loop_dev" --no-user-interaction >/dev/null
+udisksctl loop-delete -b "$loop_dev" --no-user-interaction >/dev/null
+loop_dev=""
+
+log "Wrapping GPT disk image"
+disk="$out_dir/omarchy-mac-usb.img"
+rm -f "$disk"
+truncate -s "$disk_bytes" "$disk"
+parted -s "$disk" mklabel gpt \
+  mkpart ESP fat32 1MiB 513MiB \
+  set 1 esp on
+dd if="$work/esp.fat" of="$disk" bs=1M seek=1 conv=notrunc status=none
+
+# Loose copies for iterating onto an existing stick without dd.
+cp "$work/BOOTAA64.EFI" "$out_dir/BOOTAA64.EFI"
+cp "$work/initramfs-omarchy-usb.img" "$out_dir/initramfs-omarchy-usb.img"
+cp "$work/root.img" "$out_dir/root.img"
+cp /boot/vmlinuz-linux-asahi "$out_dir/vmlinuz-linux-asahi"
+cp "$repo_root/configs/usb/grub.cfg" "$out_dir/grub.cfg"
+
+git_ref="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+cat > "$out_dir/BUILD_INFO" <<EOF
+artifact: omarchy-mac-usb
+built_from_ref: $git_ref
+kernel: linux-asahi $kver
+contract: GPT disk image, one FAT32 ESP labelled OMARCHYISO
+  EFI/BOOT/BOOTAA64.EFI (grub-mkstandalone)
+  /vmlinuz-linux-asahi + /initramfs-omarchy-usb.img + /root.img
+flash: dd if=omarchy-mac-usb.img of=/dev/sdX bs=4M status=progress conv=fsync
+EOF
+
+log "Wrote $disk ($(du -h "$disk" | cut -f1))"

--- a/builder/build-usb-image.sh
+++ b/builder/build-usb-image.sh
@@ -79,6 +79,7 @@ fi
 
 mkdir -p "$mnt/EFI/BOOT" "$mnt/grub"
 cp "$work/BOOTAA64.EFI" "$mnt/EFI/BOOT/BOOTAA64.EFI"
+cp "$repo_root/configs/usb/grub.cfg" "$mnt/EFI/BOOT/grub.cfg"
 cp "$repo_root/configs/usb/grub.cfg" "$mnt/grub/grub.cfg"
 cp /boot/vmlinuz-linux-asahi "$mnt/vmlinuz-linux-asahi"
 cp "$work/initramfs-omarchy-usb.img" "$mnt/initramfs-omarchy-usb.img"

--- a/builder/build-usb-rootimg.sh
+++ b/builder/build-usb-rootimg.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Usage: build-usb-rootimg.sh <out-root.img>
+# Tiny ext4 image with a marker file. Stand-in for a full Omarchy rootfs.
+set -euo pipefail
+
+out="$1"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+mkdir -p "$work/tree"
+printf 'omarchy-mac-live-ok usb-image %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  > "$work/tree/omarchy-mac-live-ok"
+
+rm -f "$out"
+truncate -s 32M "$out"
+mkfs.ext4 -F -q -L OMARCHYLIVE -d "$work/tree" "$out"

--- a/builder/build-usb-rootimg.sh
+++ b/builder/build-usb-rootimg.sh
@@ -1,16 +1,65 @@
 #!/bin/bash
 # Usage: build-usb-rootimg.sh <out-root.img>
-# Tiny ext4 image with a marker file. Stand-in for a full Omarchy rootfs.
+# Tiny ext4 root with a real /sbin/init (busybox + its shared libraries).
+# The overlay spike failed switch_root because busybox was a dangling symlink
+# and the binary is dynamically linked — copy the ELF and libc, not a link.
 set -euo pipefail
 
 out="$1"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bb=/usr/lib/initcpio/busybox
+live_init="$repo_root/configs/usb/live-init"
+
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+[[ -x $bb ]] || fail "no $bb — mkinitcpio is required"
+[[ -f $live_init ]] || fail "missing $live_init"
+[[ ! -L $bb ]] || fail "$bb is a symlink; copy the ELF"
+command -v readelf >/dev/null && command -v ldd >/dev/null && command -v file >/dev/null \
+  || fail "need readelf, ldd, and file to pack busybox and its libraries"
+
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
+tree="$work/tree"
 
-mkdir -p "$work/tree"
+copy_into_tree() {
+  local src=$1 rel=$2
+  mkdir -p "$tree/$(dirname "$rel")"
+  cp -L "$src" "$tree$rel"
+  chmod 755 "$tree$rel"
+  [[ ! -L $tree$rel ]] || fail "$rel is still a symlink after cp -L"
+}
+
+copy_shared_objects() {
+  local bin=$1 interp lib
+  interp=$(readelf -l "$bin" | sed -n 's/.*program interpreter: \([^]]*\).*/\1/p')
+  if [[ -n $interp ]]; then
+    copy_into_tree "$(readlink -f "$interp")" "$interp"
+  fi
+  while read -r lib; do
+    [[ -e $lib ]] || continue
+    copy_into_tree "$(readlink -f "$lib")" "$lib"
+  done < <(ldd "$bin" | awk '/=> \// {print $3}')
+}
+
+mkdir -p "$tree/bin" "$tree/sbin" "$tree/proc" "$tree/sys" "$tree/dev" "$tree/run" "$tree/tmp"
+
 printf 'omarchy-mac-live-ok usb-image %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  > "$work/tree/omarchy-mac-live-ok"
+  > "$tree/omarchy-mac-live-ok"
+
+copy_into_tree "$bb" /bin/busybox
+copy_shared_objects "$bb"
+for applet in sh ash cat ls echo sleep; do
+  ln -sf busybox "$tree/bin/$applet"
+done
+
+install -m755 "$live_init" "$tree/sbin/init"
+cp -L "$tree/sbin/init" "$tree/init"
+chmod 755 "$tree/init"
+
+file -b "$tree/bin/busybox" | grep -q ELF || fail "busybox in root.img is not an ELF"
+[[ -x $tree/sbin/init && ! -L $tree/sbin/init ]] || fail "/sbin/init must be a regular executable"
 
 rm -f "$out"
 truncate -s 32M "$out"
-mkfs.ext4 -F -q -L OMARCHYLIVE -d "$work/tree" "$out"
+mkfs.ext4 -F -q -L OMARCHYLIVE -d "$tree" "$out"

--- a/configs/usb-initcpio/hooks/omarchy-usb-live
+++ b/configs/usb-initcpio/hooks/omarchy-usb-live
@@ -1,0 +1,87 @@
+#!/usr/bin/ash
+# SPDX-License-Identifier: MIT
+#
+# After asahi firmware + udev: mount the USB ESP, loop-mount root.img,
+# overlay a tmpfs, announce readiness. Pid 1 stays in the initramfs
+# (a real rootfs with /sbin/init is a later milestone).
+
+USB_LABEL="OMARCHYISO"
+USB_MOUNT="/run/omarchy-usb"
+LIVE_MOUNT="/run/omarchy-root"
+OVL_MOUNT="/run/omarchy-ovl"
+NEW_ROOT="/new_root"
+MARKER="omarchy-mac-live-ok"
+
+wait_for_usb() {
+  i=0
+  while [ "$i" -lt 30 ]; do
+    if [ -e /dev/disk/by-label/"$USB_LABEL" ] || [ -b /dev/sda1 ]; then
+      return 0
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+hang() {
+  echo "==> $*" > /dev/console
+  echo "==> $*"
+  while true; do
+    sleep 3600
+  done
+}
+
+run_hook() {
+  if command -v udevadm >/dev/null 2>&1; then
+    udevadm settle --timeout=10 2>/dev/null
+    udevadm trigger --action=add 2>/dev/null
+    udevadm settle --timeout=10 2>/dev/null
+  fi
+  sleep 2
+
+  if ! wait_for_usb; then
+    hang "omarchy-usb-live: USB volume $USB_LABEL never appeared"
+  fi
+
+  if [ -e /dev/disk/by-label/"$USB_LABEL" ]; then
+    usb_dev=$(readlink -f /dev/disk/by-label/"$USB_LABEL")
+  else
+    usb_dev=/dev/sda1
+  fi
+
+  mkdir -p "$USB_MOUNT"
+  if ! mount -t vfat -o ro "$usb_dev" "$USB_MOUNT"; then
+    hang "omarchy-usb-live: failed to mount $usb_dev"
+  fi
+
+  if [ ! -f "$USB_MOUNT/root.img" ]; then
+    hang "omarchy-usb-live: no root.img on $usb_dev"
+  fi
+
+  if command -v udevadm >/dev/null 2>&1; then
+    udevadm settle --timeout=5 2>/dev/null
+  fi
+
+  loop_dev=$(losetup -f --show "$USB_MOUNT/root.img") || hang "omarchy-usb-live: losetup failed"
+  mkdir -p "$LIVE_MOUNT"
+  if ! mount -t ext4 -o ro "$loop_dev" "$LIVE_MOUNT"; then
+    hang "omarchy-usb-live: failed to mount root.img"
+  fi
+
+  mkdir -p "$OVL_MOUNT" "$NEW_ROOT"
+  mount -t tmpfs tmpfs "$OVL_MOUNT"
+  mkdir -p "$OVL_MOUNT/upper" "$OVL_MOUNT/work"
+  if ! mount -t overlay overlay \
+      -o "lowerdir=$LIVE_MOUNT,upperdir=$OVL_MOUNT/upper,workdir=$OVL_MOUNT/work" \
+      "$NEW_ROOT"; then
+    hang "omarchy-usb-live: overlay mount failed"
+  fi
+
+  echo "writable overlay" > "$NEW_ROOT/omarchy-mac-overlay-write"
+
+  echo "==> OMARCHY_MAC_USB_READY" > /dev/console
+  echo "==> OMARCHY_MAC_USB_READY usb=$usb_dev loop=$loop_dev marker=$(cat "$LIVE_MOUNT/$MARKER" 2>/dev/null)"
+
+  hang "omarchy-usb-live: live overlay is at $NEW_ROOT (no switch_root yet)"
+}

--- a/configs/usb-initcpio/hooks/omarchy-usb-live
+++ b/configs/usb-initcpio/hooks/omarchy-usb-live
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MIT
 #
 # After asahi firmware + udev: mount the USB ESP, loop-mount root.img,
-# overlay a tmpfs, announce readiness. Pid 1 stays in the initramfs
-# (a real rootfs with /sbin/init is a later milestone).
+# overlay a tmpfs, switch_root into /sbin/init on that overlay.
 
 USB_LABEL="OMARCHYISO"
 USB_MOUNT="/run/omarchy-usb"
@@ -25,7 +24,7 @@ wait_for_usb() {
 }
 
 hang() {
-  echo "==> $*" > /dev/console
+  echo "==> $*" >/dev/console
   echo "==> $*"
   while true; do
     sleep 3600
@@ -78,10 +77,26 @@ run_hook() {
     hang "omarchy-usb-live: overlay mount failed"
   fi
 
-  echo "writable overlay" > "$NEW_ROOT/omarchy-mac-overlay-write"
+  echo "writable overlay" >"$NEW_ROOT/omarchy-mac-overlay-write"
 
-  echo "==> OMARCHY_MAC_USB_READY" > /dev/console
+  if [ ! -x "$NEW_ROOT/sbin/init" ] || [ -L "$NEW_ROOT/sbin/init" ]; then
+    hang "omarchy-usb-live: /sbin/init missing or is a symlink"
+  fi
+  if [ -L "$NEW_ROOT/bin/busybox" ]; then
+    hang "omarchy-usb-live: busybox is a symlink (switch_root would ENOENT)"
+  fi
+
+  echo "==> OMARCHY_MAC_USB_READY" >/dev/console
   echo "==> OMARCHY_MAC_USB_READY usb=$usb_dev loop=$loop_dev marker=$(cat "$LIVE_MOUNT/$MARKER" 2>/dev/null)"
 
-  hang "omarchy-usb-live: live overlay is at $NEW_ROOT (no switch_root yet)"
+  mkdir -p "$NEW_ROOT/proc" "$NEW_ROOT/sys" "$NEW_ROOT/dev" "$NEW_ROOT/run"
+  mount --move /proc "$NEW_ROOT/proc" 2>/dev/null || mount -t proc proc "$NEW_ROOT/proc"
+  mount --move /sys "$NEW_ROOT/sys" 2>/dev/null || mount -t sysfs sys "$NEW_ROOT/sys"
+  mount --move /dev "$NEW_ROOT/dev" 2>/dev/null || mount --bind /dev "$NEW_ROOT/dev"
+  mount --move /run "$NEW_ROOT/run" 2>/dev/null || true
+
+  echo "==> omarchy-usb-live: switch_root $NEW_ROOT /sbin/init" >/dev/console
+  exec switch_root "$NEW_ROOT" /sbin/init
+
+  hang "omarchy-usb-live: switch_root returned"
 }

--- a/configs/usb-initcpio/install/omarchy-usb-live
+++ b/configs/usb-initcpio/install/omarchy-usb-live
@@ -7,6 +7,7 @@ build() {
   add_binary /usr/bin/losetup
   add_binary /usr/bin/mount
   add_binary /usr/bin/umount
+  add_binary /usr/bin/switch_root
   add_full_dir /usr/share/asahi-scripts
   add_runscript
 }
@@ -14,6 +15,6 @@ build() {
 help() {
   cat <<HELPEOF
 Find the USB volume labelled OMARCHYISO, loop-mount root.img, overlay a
-tmpfs, print a readiness line, and keep pid 1 alive. Does not switch_root.
+tmpfs, and switch_root into /sbin/init on that overlay.
 HELPEOF
 }

--- a/configs/usb-initcpio/install/omarchy-usb-live
+++ b/configs/usb-initcpio/install/omarchy-usb-live
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+build() {
+  add_binary /usr/bin/lsblk
+  add_binary /usr/bin/lsmod
+  add_binary /usr/bin/dmesg
+  add_binary /usr/bin/losetup
+  add_binary /usr/bin/mount
+  add_binary /usr/bin/umount
+  add_full_dir /usr/share/asahi-scripts
+  add_runscript
+}
+
+help() {
+  cat <<HELPEOF
+Find the USB volume labelled OMARCHYISO, loop-mount root.img, overlay a
+tmpfs, print a readiness line, and keep pid 1 alive. Does not switch_root.
+HELPEOF
+}

--- a/configs/usb-initcpio/mkinitcpio.conf
+++ b/configs/usb-initcpio/mkinitcpio.conf
@@ -19,7 +19,7 @@ MODULES=(
   nls_iso8859_1
 )
 
-BINARIES=(lsblk lsmod losetup)
+BINARIES=(lsblk lsmod losetup switch_root)
 
 FILES=()
 

--- a/configs/usb-initcpio/mkinitcpio.conf
+++ b/configs/usb-initcpio/mkinitcpio.conf
@@ -1,0 +1,29 @@
+# Live USB initramfs for Apple Silicon. Do not trust the packaged asahi
+# hook for Type-C USB — it still lists dwc3-of-simple, not dwc3-apple.
+
+MODULES=(
+  apple-tunable
+  phy_apple_atc
+  mux_apple_display_crossbar
+  typec
+  tps6598x_core
+  tps6598x
+  dwc3
+  dwc3_apple
+  xhci_plat_hcd
+  xhci_hcd
+  usb_storage
+  uas
+  loop
+  overlay
+  nls_iso8859_1
+)
+
+BINARIES=(lsblk lsmod losetup)
+
+FILES=()
+
+HOOKS=(base asahi udev omarchy-usb-live)
+
+COMPRESSION="zstd"
+COMPRESSION_OPTIONS=(-T0 -3)

--- a/configs/usb/grub.cfg
+++ b/configs/usb/grub.cfg
@@ -1,0 +1,11 @@
+# USB ESP. U-Boot loads EFI/BOOT/BOOTAA64.EFI; this is what that GRUB runs.
+set timeout=5
+set default=0
+
+search --no-floppy --label OMARCHYISO --set=root
+
+menuentry 'Omarchy Mac live (USB)' {
+  echo 'GRUB is running from the USB ESP'
+  linux /vmlinuz-linux-asahi loglevel=7
+  initrd /initramfs-omarchy-usb.img
+}

--- a/configs/usb/grub.cfg
+++ b/configs/usb/grub.cfg
@@ -1,8 +1,12 @@
-# USB ESP. U-Boot loads EFI/BOOT/BOOTAA64.EFI; this is what that GRUB runs.
-set timeout=5
+# USB ESP. If you see "Omarchy Linux" / "Advanced options", this file
+# did not run — that menu is NVMe GRUB.
+echo '========================================'
+echo '  OMARCHY USB GRUB (not the NVMe ESP)'
+echo '========================================'
+set timeout=8
 set default=0
 
-search --no-floppy --label OMARCHYISO --set=root
+search --no-floppy --file /initramfs-omarchy-usb.img --set=root
 
 menuentry 'Omarchy Mac live (USB)' {
   echo 'GRUB is running from the USB ESP'

--- a/configs/usb/live-init
+++ b/configs/usb/live-init
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Pid 1 after switch_root onto the USB overlay. Hang so the screen can
+# be photographed. A full userspace (systemd / installer) is later.
+#
+# Initramfs PATH is /usr/bin; after switch_root our applets live in /bin.
+export PATH=/bin:/usr/bin
+
+msg() {
+  echo "==> $*" >/dev/console
+  echo "==> $*"
+}
+
+msg "OMARCHY_MAC_USB_USERSPACE pid=$$ marker=$(/bin/cat /omarchy-mac-live-ok 2>/dev/null) overlay=$(/bin/cat /omarchy-mac-overlay-write 2>/dev/null)"
+echo "userspace write" >/omarchy-mac-userspace
+
+while true; do
+  sleep 3600
+done

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -285,15 +285,22 @@ bootflow select 0
 bootflow boot
 ```
 
-Still open before S4 is comfortable: overlay + `switch_root` into a tiny
-userspace, and `iwctl`/`NetworkManager` in that environment. Those can ride
-on the same stick.
+Overlay of USB `root.img` is proven on the `--usb` image (2026-08-23,
+`OMARCHY_MAC_USB_READY`, hang at `/new_root`). Still open before S4:
+`switch_root` into a tiny userspace, and `iwctl`/`NetworkManager` in that
+environment. Those can ride on the same stick.
+
+A warm reboot often leaves Type-C unenumerated in U-Boot (`0 Storage
+Device(s) found`). Cold start (shutdown, then power on) is required.
+`bootflow select` of the USB row can still load NVMe's
+`/EFI/BOOT/BOOTAA64.EFI`; load the stick's GRUB with `load usb` + `bootefi`.
 
 ### S2 — Populate the repo, and the builder container
 
-This document is the first real commit. Then `bin/omarchy-mac-iso-make` running
+Native `./bin/omarchy-mac-iso-make --usb` on this Mac produces a GPT image
+that boots on metal (2026-08-23). Then the same builder in
 `docker --platform linux/arm64` from Arch Linux ARM with `[asahi-alarm]` and
-`[omarchy-aarch64]`. Native on this Mac first, then CI.
+`[omarchy-aarch64]`, then CI.
 
 ### S3 — The rootfs artifact
 
@@ -335,10 +342,10 @@ GitHub Releases vs R2 vs split assets.
 ## Verification
 
 1. **S1 (done):** USB through U-Boot, vendor firmware present, `dwc3-apple`
-   bound, `root.img` loop-mounted. Remaining: Wi-Fi in the live env, overlay
-   + `switch_root`.
-2. `./bin/omarchy-mac-iso-make` produces `release/*.img` on this Mac; `test/unit`
-   green; `bash -n` over every script.
+   bound, `root.img` loop-mounted. Overlay on the `--usb` image: done
+   2026-08-23. Remaining: Wi-Fi in the live env, `switch_root`.
+2. `./bin/omarchy-mac-iso-make --usb` produces `release/*.img` on this Mac and
+   boots; `test/unit` green; `bash -n` over every script. Container still open.
 3. Install to an external disk, unencrypted then encrypted. Boot each. Confirm
    Wi-Fi, GPU/Quickshell bar at notch height, audio, media keys,
    `omarchy snapshot restore` sees `@factory`.

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -45,7 +45,7 @@ Spikes live in `~/code/omarchy-mac-iso-spike/`. Reports:
 | Os-package zip, from source | Raw zip: `esp/` tree + `root.img` (size multiple of 4 KiB). Optional `boot.img`, `icon`. `fdcopy` onto `/dev/rdiskNsM`. No sparse format. `INSTALLER_DATA` / `REPO_BASE` is the supported third-party hook. `supported_fw` filters IPSW versions (`12.3`, `12.3.1`, `13.5`, `14.8.3`), not kernel features. |
 | Alarm size precedent is **Minimal**, not a desktop | Alarm Minimal `root.img` is 2,209,614,225 bytes; Desktop is 12.7 GB in a **1.88 GiB** zip. This machine's `@` subvolume is ~13 GB (`du -sx /` does not cross `@home`). A full Omarchy image will look like Desktop, not Minimal. GitHub Releases' 2 GiB per-file cap is tight. |
 
-Not yet proven on the stick: Wi-Fi association in the live environment, overlay + `switch_root` into a writable userspace, or an install `dd` onto a target disk.
+Not yet proven on the stick: Wi-Fi association in the live environment, or an install `dd` onto a target disk. Overlay + `switch_root` into busybox pid 1 is done (2026-08-23).
 
 ## Architecture: one rootfs, two front doors
 
@@ -276,24 +276,19 @@ Triage, do not bulk-delete: keep `ipcfix/`, `malikpr/`, `upstream-pr/`,
 ### S1 — Hardware spike — **done 2026-08-22**
 
 USB through U-Boot, firmware from the internal ESP, `dwc3-apple` binds, loop
-mount of `root.img`. Commands that actually worked on this NVMe-first machine:
-
-```
-usb start
-bootflow scan -l usb
-bootflow select 0
-bootflow boot
-```
-
-Overlay of USB `root.img` is proven on the `--usb` image (2026-08-23,
-`OMARCHY_MAC_USB_READY`, hang at `/new_root`). Still open before S4:
-`switch_root` into a tiny userspace, and `iwctl`/`NetworkManager` in that
-environment. Those can ride on the same stick.
+mount of `root.img`. Overlay + `switch_root` into busybox pid 1 is proven on
+the `--usb` image (2026-08-23, `OMARCHY_MAC_USB_USERSPACE pid=1`). Still open
+before S4: `iwctl`/`NetworkManager` in that environment.
 
 A warm reboot often leaves Type-C unenumerated in U-Boot (`0 Storage
 Device(s) found`). Cold start (shutdown, then power on) is required.
 `bootflow select` of the USB row can still load NVMe's
-`/EFI/BOOT/BOOTAA64.EFI`; load the stick's GRUB with `load usb` + `bootefi`.
+`/EFI/BOOT/BOOTAA64.EFI`. Commands that worked on this NVMe-first machine:
+
+```
+load usb 0:1 ${kernel_addr_r} /EFI/BOOT/BOOTAA64.EFI
+bootefi ${kernel_addr_r} ${fdtcontroladdr}
+```
 
 ### S2 — Populate the repo, and the builder container
 
@@ -342,8 +337,9 @@ GitHub Releases vs R2 vs split assets.
 ## Verification
 
 1. **S1 (done):** USB through U-Boot, vendor firmware present, `dwc3-apple`
-   bound, `root.img` loop-mounted. Overlay on the `--usb` image: done
-   2026-08-23. Remaining: Wi-Fi in the live env, `switch_root`.
+   bound, `root.img` loop-mounted, overlay + `switch_root` into busybox pid 1
+   (`OMARCHY_MAC_USB_USERSPACE pid=1`, 2026-08-23). Remaining: Wi-Fi in the
+   live env.
 2. `./bin/omarchy-mac-iso-make --usb` produces `release/*.img` on this Mac and
    boots; `test/unit` green; `bash -n` over every script. Container still open.
 3. Install to an external disk, unencrypted then encrypted. Boot each. Confirm

--- a/test/unit
+++ b/test/unit
@@ -40,6 +40,12 @@ check "omarchy-mac-iso-boot --help works offline" "${repo_root}/bin/omarchy-mac-
 check "usb grub.cfg finds initramfs-omarchy-usb.img" \
   grep -q initramfs-omarchy-usb.img "${repo_root}/configs/usb/grub.cfg"
 check "usb mkinitcpio lists dwc3_apple" grep -q dwc3_apple "${repo_root}/configs/usb-initcpio/mkinitcpio.conf"
+check "sh -n live-init" sh -n "${repo_root}/configs/usb/live-init"
+check "live-init sets PATH to /bin" grep -q 'PATH=/bin' "${repo_root}/configs/usb/live-init"
+check "usb hook execs switch_root" grep -q 'exec switch_root' \
+  "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
+check "usb rootimg copies initcpio busybox" grep -q /usr/lib/initcpio/busybox \
+  "${repo_root}/builder/build-usb-rootimg.sh"
 
 if (( failures > 0 )); then
     echo "${failures} failure(s)"

--- a/test/unit
+++ b/test/unit
@@ -34,7 +34,11 @@ check "MINIROOTFS_SHA256 is 64 hex chars" bash -c "[[ '${MINIROOTFS_SHA256}' =~ 
 check "KERNEL_PKG_SHA256 is 64 hex chars" bash -c "[[ '${KERNEL_PKG_SHA256}' =~ ^[0-9a-f]{64}\$ ]]"
 
 check "omarchy-mac-iso-make --help works offline" "${repo_root}/bin/omarchy-mac-iso-make" --help
+check "omarchy-mac-iso-make --help mentions --usb" \
+  grep -q -- '--usb' <("${repo_root}/bin/omarchy-mac-iso-make" --help)
 check "omarchy-mac-iso-boot --help works offline" "${repo_root}/bin/omarchy-mac-iso-boot" --help
+check "usb grub.cfg searches OMARCHYISO" grep -q OMARCHYISO "${repo_root}/configs/usb/grub.cfg"
+check "usb mkinitcpio lists dwc3_apple" grep -q dwc3_apple "${repo_root}/configs/usb-initcpio/mkinitcpio.conf"
 
 if (( failures > 0 )); then
     echo "${failures} failure(s)"

--- a/test/unit
+++ b/test/unit
@@ -37,7 +37,8 @@ check "omarchy-mac-iso-make --help works offline" "${repo_root}/bin/omarchy-mac-
 check "omarchy-mac-iso-make --help mentions --usb" \
   grep -q -- '--usb' <("${repo_root}/bin/omarchy-mac-iso-make" --help)
 check "omarchy-mac-iso-boot --help works offline" "${repo_root}/bin/omarchy-mac-iso-boot" --help
-check "usb grub.cfg searches OMARCHYISO" grep -q OMARCHYISO "${repo_root}/configs/usb/grub.cfg"
+check "usb grub.cfg finds initramfs-omarchy-usb.img" \
+  grep -q initramfs-omarchy-usb.img "${repo_root}/configs/usb/grub.cfg"
 check "usb mkinitcpio lists dwc3_apple" grep -q dwc3_apple "${repo_root}/configs/usb-initcpio/mkinitcpio.conf"
 
 if (( failures > 0 )); then


### PR DESCRIPTION
## Summary

Adds `./bin/omarchy-mac-iso-make --usb`: a GPT stick image that boots on Apple Silicon (m1n1 → U-Boot → GRUB `BOOTAA64.EFI` → `linux-asahi` → overlay → busybox pid 1). Default `make` is still Jae's Alpine QEMU harness; Alpine is not the installer.

Proven on an M2 Max: `OMARCHY_MAC_USB_READY` then `OMARCHY_MAC_USB_USERSPACE pid=1`.

## Notes from metal

- Cold start (shutdown, then power on). A warm reboot often leaves Type-C unenumerated in U-Boot.
- On a machine that already has Linux on NVMe, `bootflow select` can load NVMe's `/EFI/BOOT/BOOTAA64.EFI` (same path on both ESPs). Load the stick explicitly:

```
load usb 0:1 ${kernel_addr_r} /EFI/BOOT/BOOTAA64.EFI
bootefi ${kernel_addr_r} ${fdtcontroladdr}
```

Do not `saveenv`. This is not a full Omarchy desktop or installer yet — tiny `root.img`, no TUI.