### PR TITLE
USB image: GPT ESP + btrfs payload partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ On a machine that already runs `linux-asahi`:
 ./bin/omarchy-mac-iso-make --usb
 ```
 
-Writes `release/omarchy-mac-iso-usb/omarchy-mac-usb.img` — GPT, one FAT32
-ESP labelled `OMARCHYISO`, standalone GRUB, this host's `linux-asahi`,
-an initramfs with `dwc3-apple`, and a tiny `root.img`. No root required.
+Writes `release/omarchy-mac-iso-usb/omarchy-mac-usb.img` — GPT with a FAT32
+ESP labelled `OMARCHYISO` (standalone GRUB, this host's `linux-asahi`,
+initramfs with `dwc3-apple`) and a btrfs payload labelled `OMARCHYLIVE`
+(subvol `@`, tiny busybox `/sbin/init` until S3). No root required. Copying
+files onto an existing FAT stick is not enough — the payload is its own
+partition.
 
 Flash (destroys the target stick):
 

--- a/bin/omarchy-mac-iso-make
+++ b/bin/omarchy-mac-iso-make
@@ -27,8 +27,8 @@ Usage: omarchy-mac-iso-make [--usb]
 Default: M0 QEMU artifact (Alpine linux-virt kernel + initramfs) into
 release/omarchy-mac-iso-arm64/. Does not boot a Mac.
 
---usb: native Apple Silicon GPT image (linux-asahi, GRUB ESP, root.img)
-into release/omarchy-mac-iso-usb/. Requires linux-asahi on the host.
+--usb: native Apple Silicon GPT image (linux-asahi, GRUB ESP, btrfs
+payload) into release/omarchy-mac-iso-usb/. Requires linux-asahi on the host.
 EOF
 }
 

--- a/builder/build-usb-image.sh
+++ b/builder/build-usb-image.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Usage: build-usb-image.sh <out-dir>
 # Native Apple Silicon build: GPT disk image with a FAT ESP (GRUB, linux-asahi,
-# live initramfs, root.img). Unprivileged: udisks loop-mounts a FAT file.
+# live initramfs) plus a btrfs payload partition (label OMARCHYLIVE, subvol=@).
+# Unprivileged: udisks loop-mounts the filesystem images; dd into the GPT file.
 set -euo pipefail
 
 out_dir="$1"
@@ -32,8 +33,10 @@ trap cleanup EXIT
 
 mkdir -p "$work" "$out_dir"
 
-log "Building root.img"
-"$repo_root/builder/build-usb-rootimg.sh" "$work/root.img"
+log "Building btrfs payload (OMARCHYLIVE)"
+"$repo_root/builder/build-usb-rootimg.sh" "$work/payload.img"
+payload_bytes=$(stat -c %s "$work/payload.img")
+payload_mib=$(( (payload_bytes + 1024 * 1024 - 1) / (1024 * 1024) ))
 
 log "Building live initramfs (linux-asahi $kver, dwc3-apple)"
 mkinitcpio -n \
@@ -46,15 +49,17 @@ mkinitcpio -n \
 log "Building standalone GRUB"
 grub-mkstandalone -O arm64-efi \
   --fonts="" --locales="" --themes="" \
-  --install-modules="linux fat ext2 part_gpt search search_label search_fs_uuid echo normal configfile gzio reboot sleep" \
+  --install-modules="linux fat ext2 btrfs part_gpt search search_label search_fs_uuid echo normal configfile gzio reboot sleep" \
   --modules="part_gpt fat search search_label linux echo normal" \
   -o "$work/BOOTAA64.EFI" \
   "boot/grub/grub.cfg=$repo_root/configs/usb/grub.cfg"
 
-# 512 MiB FAT ESP, GPT wrapper with 1 MiB headroom.
-fat_kb=$((512 * 1024))
-fat_bytes=$((fat_kb * 1024))
-disk_bytes=$((fat_bytes + 2 * 1024 * 1024))
+# 512 MiB FAT ESP, then the btrfs payload, 1 MiB GPT head/tail.
+fat_mib=512
+fat_kb=$((fat_mib * 1024))
+esp_end_mib=$((1 + fat_mib))
+payload_end_mib=$((esp_end_mib + payload_mib))
+disk_bytes=$(( (payload_end_mib + 1) * 1024 * 1024 ))
 
 log "Formatting ESP"
 mkfs.vfat -F 32 -n OMARCHYISO -C "$work/esp.fat" "$fat_kb" >/dev/null
@@ -64,7 +69,6 @@ map_out="$(udisksctl loop-setup -f "$work/esp.fat" --no-user-interaction)"
 loop_dev="$(printf '%s\n' "$map_out" | grep -oE '/dev/loop[0-9]+')"
 [[ -n $loop_dev ]] || fail "udisksctl loop-setup did not print a loop device"
 
-# udisks often auto-mounts; wait for it
 mnt=""
 for _ in $(seq 1 20); do
   mnt="$(findmnt -n -o TARGET "$loop_dev" 2>/dev/null || true)"
@@ -83,26 +87,26 @@ cp "$repo_root/configs/usb/grub.cfg" "$mnt/EFI/BOOT/grub.cfg"
 cp "$repo_root/configs/usb/grub.cfg" "$mnt/grub/grub.cfg"
 cp /boot/vmlinuz-linux-asahi "$mnt/vmlinuz-linux-asahi"
 cp "$work/initramfs-omarchy-usb.img" "$mnt/initramfs-omarchy-usb.img"
-cp "$work/root.img" "$mnt/root.img"
 sync
 
 udisksctl unmount -b "$loop_dev" --no-user-interaction >/dev/null
 udisksctl loop-delete -b "$loop_dev" --no-user-interaction >/dev/null
 loop_dev=""
 
-log "Wrapping GPT disk image"
+log "Wrapping GPT disk image (ESP ${fat_mib}MiB + payload ${payload_mib}MiB)"
 disk="$out_dir/omarchy-mac-usb.img"
 rm -f "$disk"
 truncate -s "$disk_bytes" "$disk"
 parted -s "$disk" mklabel gpt \
-  mkpart ESP fat32 1MiB 513MiB \
-  set 1 esp on
+  mkpart ESP fat32 1MiB "${esp_end_mib}MiB" \
+  set 1 esp on \
+  mkpart payload btrfs "${esp_end_mib}MiB" "${payload_end_mib}MiB"
 dd if="$work/esp.fat" of="$disk" bs=1M seek=1 conv=notrunc status=none
+dd if="$work/payload.img" of="$disk" bs=1M seek="$esp_end_mib" conv=notrunc status=none
 
-# Loose copies for iterating onto an existing stick without dd.
 cp "$work/BOOTAA64.EFI" "$out_dir/BOOTAA64.EFI"
 cp "$work/initramfs-omarchy-usb.img" "$out_dir/initramfs-omarchy-usb.img"
-cp "$work/root.img" "$out_dir/root.img"
+cp "$work/payload.img" "$out_dir/payload.img"
 cp /boot/vmlinuz-linux-asahi "$out_dir/vmlinuz-linux-asahi"
 cp "$repo_root/configs/usb/grub.cfg" "$out_dir/grub.cfg"
 
@@ -111,9 +115,10 @@ cat > "$out_dir/BUILD_INFO" <<EOF
 artifact: omarchy-mac-usb
 built_from_ref: $git_ref
 kernel: linux-asahi $kver
-contract: GPT disk image, one FAT32 ESP labelled OMARCHYISO
+contract: GPT disk image, FAT32 ESP labelled OMARCHYISO + btrfs payload labelled OMARCHYLIVE (subvol=@)
   EFI/BOOT/BOOTAA64.EFI (grub-mkstandalone)
-  /vmlinuz-linux-asahi + /initramfs-omarchy-usb.img + /root.img
+  /vmlinuz-linux-asahi + /initramfs-omarchy-usb.img on the ESP
+  payload partition is the live root (not a root.img file on FAT)
 flash: dd if=omarchy-mac-usb.img of=/dev/sdX bs=4M status=progress conv=fsync
 EOF
 

--- a/builder/build-usb-rootimg.sh
+++ b/builder/build-usb-rootimg.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-# Usage: build-usb-rootimg.sh <out-root.img>
-# Tiny ext4 root with a real /sbin/init (busybox + its shared libraries).
-# The overlay spike failed switch_root because busybox was a dangling symlink
-# and the binary is dynamically linked — copy the ELF and libc, not a link.
+# Usage: build-usb-rootimg.sh <out-payload.img>
+# Btrfs payload (label OMARCHYLIVE) with @ / @home / @log. Tiny busybox
+# /sbin/init lives on @ — S3 replaces this tree with a pacstrap'd Omarchy.
+# compress=none so a later zip still shrinks. Copy the busybox ELF and libc,
+# not a symlink (that is what panicked the overlay spike). Unprivileged:
+# mkfs.btrfs --rootdir --subvol.
 set -euo pipefail
 
 out="$1"
@@ -17,10 +19,12 @@ fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
 [[ ! -L $bb ]] || fail "$bb is a symlink; copy the ELF"
 command -v readelf >/dev/null && command -v ldd >/dev/null && command -v file >/dev/null \
   || fail "need readelf, ldd, and file to pack busybox and its libraries"
+command -v mkfs.btrfs >/dev/null || fail "need btrfs-progs"
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
-tree="$work/tree"
+rootdir="$work/root"
+tree="$rootdir/@"
 
 copy_into_tree() {
   local src=$1 rel=$2
@@ -43,6 +47,7 @@ copy_shared_objects() {
 }
 
 mkdir -p "$tree/bin" "$tree/sbin" "$tree/proc" "$tree/sys" "$tree/dev" "$tree/run" "$tree/tmp"
+mkdir -p "$rootdir/@home" "$rootdir/@log"
 
 printf 'omarchy-mac-live-ok usb-image %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   > "$tree/omarchy-mac-live-ok"
@@ -57,9 +62,14 @@ install -m755 "$live_init" "$tree/sbin/init"
 cp -L "$tree/sbin/init" "$tree/init"
 chmod 755 "$tree/init"
 
-file -b "$tree/bin/busybox" | grep -q ELF || fail "busybox in root.img is not an ELF"
+file -b "$tree/bin/busybox" | grep -q ELF || fail "busybox in payload is not an ELF"
 [[ -x $tree/sbin/init && ! -L $tree/sbin/init ]] || fail "/sbin/init must be a regular executable"
 
 rm -f "$out"
-truncate -s 32M "$out"
-mkfs.ext4 -F -q -L OMARCHYLIVE -d "$tree" "$out"
+truncate -s 128M "$out"
+mkfs.btrfs -q -L OMARCHYLIVE --csum crc32c \
+  --rootdir "$rootdir" \
+  --subvol default:@ \
+  --subvol rw:@home \
+  --subvol rw:@log \
+  "$out"

--- a/configs/usb-initcpio/hooks/omarchy-usb-live
+++ b/configs/usb-initcpio/hooks/omarchy-usb-live
@@ -1,20 +1,19 @@
 #!/usr/bin/ash
 # SPDX-License-Identifier: MIT
 #
-# After asahi firmware + udev: mount the USB ESP, loop-mount root.img,
-# overlay a tmpfs, switch_root into /sbin/init on that overlay.
+# After asahi firmware + udev: mount the btrfs payload (label OMARCHYLIVE,
+# subvol=@), overlay a tmpfs, switch_root into /sbin/init on that overlay.
 
-USB_LABEL="OMARCHYISO"
-USB_MOUNT="/run/omarchy-usb"
+PAYLOAD_LABEL="OMARCHYLIVE"
 LIVE_MOUNT="/run/omarchy-root"
 OVL_MOUNT="/run/omarchy-ovl"
 NEW_ROOT="/new_root"
 MARKER="omarchy-mac-live-ok"
 
-wait_for_usb() {
+wait_for_payload() {
   i=0
   while [ "$i" -lt 30 ]; do
-    if [ -e /dev/disk/by-label/"$USB_LABEL" ] || [ -b /dev/sda1 ]; then
+    if [ -e /dev/disk/by-label/"$PAYLOAD_LABEL" ] || [ -b /dev/sda2 ]; then
       return 0
     fi
     sleep 1
@@ -39,33 +38,19 @@ run_hook() {
   fi
   sleep 2
 
-  if ! wait_for_usb; then
-    hang "omarchy-usb-live: USB volume $USB_LABEL never appeared"
+  if ! wait_for_payload; then
+    hang "omarchy-usb-live: payload $PAYLOAD_LABEL never appeared (dd the GPT image, not a FAT file copy)"
   fi
 
-  if [ -e /dev/disk/by-label/"$USB_LABEL" ]; then
-    usb_dev=$(readlink -f /dev/disk/by-label/"$USB_LABEL")
+  if [ -e /dev/disk/by-label/"$PAYLOAD_LABEL" ]; then
+    payload_dev=$(readlink -f /dev/disk/by-label/"$PAYLOAD_LABEL")
   else
-    usb_dev=/dev/sda1
+    payload_dev=/dev/sda2
   fi
 
-  mkdir -p "$USB_MOUNT"
-  if ! mount -t vfat -o ro "$usb_dev" "$USB_MOUNT"; then
-    hang "omarchy-usb-live: failed to mount $usb_dev"
-  fi
-
-  if [ ! -f "$USB_MOUNT/root.img" ]; then
-    hang "omarchy-usb-live: no root.img on $usb_dev"
-  fi
-
-  if command -v udevadm >/dev/null 2>&1; then
-    udevadm settle --timeout=5 2>/dev/null
-  fi
-
-  loop_dev=$(losetup -f --show "$USB_MOUNT/root.img") || hang "omarchy-usb-live: losetup failed"
   mkdir -p "$LIVE_MOUNT"
-  if ! mount -t ext4 -o ro "$loop_dev" "$LIVE_MOUNT"; then
-    hang "omarchy-usb-live: failed to mount root.img"
+  if ! mount -t btrfs -o ro,subvol=@ "$payload_dev" "$LIVE_MOUNT"; then
+    hang "omarchy-usb-live: failed to mount $payload_dev subvol=@"
   fi
 
   mkdir -p "$OVL_MOUNT" "$NEW_ROOT"
@@ -87,7 +72,7 @@ run_hook() {
   fi
 
   echo "==> OMARCHY_MAC_USB_READY" >/dev/console
-  echo "==> OMARCHY_MAC_USB_READY usb=$usb_dev loop=$loop_dev marker=$(cat "$LIVE_MOUNT/$MARKER" 2>/dev/null)"
+  echo "==> OMARCHY_MAC_USB_READY payload=$payload_dev marker=$(cat "$LIVE_MOUNT/$MARKER" 2>/dev/null)"
 
   mkdir -p "$NEW_ROOT/proc" "$NEW_ROOT/sys" "$NEW_ROOT/dev" "$NEW_ROOT/run"
   mount --move /proc "$NEW_ROOT/proc" 2>/dev/null || mount -t proc proc "$NEW_ROOT/proc"

--- a/configs/usb-initcpio/install/omarchy-usb-live
+++ b/configs/usb-initcpio/install/omarchy-usb-live
@@ -14,7 +14,7 @@ build() {
 
 help() {
   cat <<HELPEOF
-Find the USB volume labelled OMARCHYISO, loop-mount root.img, overlay a
+Find the btrfs payload labelled OMARCHYLIVE, mount subvol=@, overlay a
 tmpfs, and switch_root into /sbin/init on that overlay.
 HELPEOF
 }

--- a/configs/usb-initcpio/mkinitcpio.conf
+++ b/configs/usb-initcpio/mkinitcpio.conf
@@ -16,6 +16,7 @@ MODULES=(
   uas
   loop
   overlay
+  btrfs
   nls_iso8859_1
 )
 

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -68,14 +68,17 @@ image zipping to 1.88 GiB only works because the filesystem data is still
 compressible. Internal btrfs zstd makes the zip larger, not smaller. After
 install, new writes can compress.
 
-Two layouts that S1 showed both work. Prefer (a) for shipping; (b) is what the
-spike used.
+Two layouts that S1 showed both work. **(a) is what `--usb` ships**, proven on
+metal 2026-08-23 (`payload=/dev/sda2`, `OMARCHY_MAC_USB_USERSPACE pid=1`).
+(b) was the spike and the first busybox image.
 
 - **(a) Payload partition that *is* the btrfs image.** GPT: FAT32 ESP + one
-  Linux partition. Live boot mounts that partition read-only and overlays a
-  tmpfs, then `switch_root`. Install is `dd` of the partition onto the target.
+  Linux partition labelled `OMARCHYLIVE`, subvol `@`. Live boot mounts that
+  partition read-only and overlays a tmpfs, then `switch_root`. Install is
+  `dd` of the partition onto the target.
 - **(b) `root.img` as a file on the FAT ESP.** Live boot `losetup` + mount.
-  Fine for development; extra loop layer in production.
+  Fine for development; extra loop layer in production. A real Omarchy root
+  will not fit on the 512 MiB ESP.
 
 Live boot command line: `systemd.unit=omarchy-mac-install.target` so only the
 installer starts. Booting the default target later gives a live desktop for
@@ -293,9 +296,11 @@ bootefi ${kernel_addr_r} ${fdtcontroladdr}
 ### S2 — Populate the repo, and the builder container
 
 Native `./bin/omarchy-mac-iso-make --usb` on this Mac produces a GPT image
-that boots on metal (2026-08-23). Then the same builder in
-`docker --platform linux/arm64` from Arch Linux ARM with `[asahi-alarm]` and
-`[omarchy-aarch64]`, then CI.
+(ESP + btrfs payload) that boots on metal (2026-08-23, payload partition
+not a `root.img` loop). Then the same builder in
+`docker --platform linux/arm64` from Arch Linux ARM with `[asahi-alarm]`
+and `[omarchy-aarch64]`, then CI. `builder/build-rootfs.sh` (S3) will replace
+the busybox tree on `@`.
 
 ### S3 — The rootfs artifact
 
@@ -337,11 +342,14 @@ GitHub Releases vs R2 vs split assets.
 ## Verification
 
 1. **S1 (done):** USB through U-Boot, vendor firmware present, `dwc3-apple`
-   bound, `root.img` loop-mounted, overlay + `switch_root` into busybox pid 1
-   (`OMARCHY_MAC_USB_USERSPACE pid=1`, 2026-08-23). Remaining: Wi-Fi in the
-   live env.
-2. `./bin/omarchy-mac-iso-make --usb` produces `release/*.img` on this Mac and
-   boots; `test/unit` green; `bash -n` over every script. Container still open.
+   bound, overlay + `switch_root` into busybox pid 1. Layout (a) on metal
+   2026-08-23: btrfs `OMARCHYLIVE` on `/dev/sda2`,
+   `OMARCHY_MAC_USB_READY payload=/dev/sda2`, then
+   `OMARCHY_MAC_USB_USERSPACE pid=1` with marker and overlay write.
+   Remaining: Wi-Fi in the live env.
+2. `./bin/omarchy-mac-iso-make --usb` produces a GPT ESP + payload image on
+   this Mac and boots; `test/unit` green; `bash -n` over every script.
+   Container still open.
 3. Install to an external disk, unencrypted then encrypted. Boot each. Confirm
    Wi-Fi, GPU/Quickshell bar at notch height, audio, media keys,
    `omarchy snapshot restore` sees `@factory`.

--- a/test/unit
+++ b/test/unit
@@ -44,8 +44,14 @@ check "sh -n live-init" sh -n "${repo_root}/configs/usb/live-init"
 check "live-init sets PATH to /bin" grep -q 'PATH=/bin' "${repo_root}/configs/usb/live-init"
 check "usb hook execs switch_root" grep -q 'exec switch_root' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
+check "usb hook mounts OMARCHYLIVE subvol=@" grep -q 'subvol=@' \
+  "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
+check "usb mkinitcpio lists btrfs" grep -q btrfs \
+  "${repo_root}/configs/usb-initcpio/mkinitcpio.conf"
 check "usb rootimg copies initcpio busybox" grep -q /usr/lib/initcpio/busybox \
   "${repo_root}/builder/build-usb-rootimg.sh"
+check "usb image builds a payload partition" grep -q 'mkpart payload' \
+  "${repo_root}/builder/build-usb-image.sh"
 
 if (( failures > 0 )); then
     echo "${failures} failure(s)"


### PR DESCRIPTION
## Summary

`--usb` now ships layout (a) from the plan: a FAT ESP for GRUB/kernel/initramfs and a separate btrfs payload for the live root. A real Omarchy `root.img` will not fit on the 512MiB FAT.

Proven on an M2 Max after `dd` onto the Lexar: `sda1` `OMARCHYISO` + `sda2` `OMARCHYLIVE`, then `OMARCHY_MAC_USB_READY payload=/dev/sda2` and `OMARCHY_MAC_USB_USERSPACE pid=1` with marker and overlay write.

Busybox pid 1 stays until S3 pacstrap into `@`. Copying files onto an old single-FAT stick is not enough — flash the GPT image.