### PR TITLE
Live USB systemd rootfs with NetworkManager and Wi-Fi

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ S3 systemd userspace (not the Omarchy desktop) — needs root, `arch-install-scr
 sudo ./bin/omarchy-mac-iso-make --usb --rootfs
 ```
 
-Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1.
-Default `--usb` without `--rootfs` still hangs at busybox pid 1.
+Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1
+(proven on an M2 Max, 2026-08-23). `base` does not include NetworkManager,
+`nmtui`, or `iwd`. Default `--usb` without `--rootfs` still hangs at busybox
+pid 1.
 
 Flash (destroys the target stick):
 
@@ -113,5 +115,7 @@ the stick should win automatically after a cold start.
 USB GRUB prints `OMARCHY USB GRUB (not the NVMe ESP)` and has one entry.
 Omarchy Linux / Advanced options means you are on NVMe.
 
-Success prints `OMARCHY_MAC_USB_READY`, then `OMARCHY_MAC_USB_USERSPACE pid=1`,
-and hangs. This is not yet a full Omarchy desktop or installer.
+Busybox `--usb` prints `OMARCHY_MAC_USB_READY`, then
+`OMARCHY_MAC_USB_USERSPACE pid=1`, and hangs. `--usb --rootfs` prints
+`OMARCHY_MAC_USB_SYSTEMD` and drops to a root shell. Neither is a full
+Omarchy desktop or installer.

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ sudo ./bin/omarchy-mac-iso-make --usb --rootfs
 ```
 
 Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1
-(proven on an M2 Max, 2026-08-23). `base` does not include NetworkManager,
-`nmtui`, or `iwd`. Default `--usb` without `--rootfs` still hangs at busybox
-pid 1.
+(proven on an M2 Max, 2026-08-23). `--rootfs` now includes `linux-asahi`
+(modules), NetworkManager, and `iwd`; vendor firmware is copied from the
+internal ESP at boot. Use `nmtui` or `iwctl`. Default `--usb` without
+`--rootfs` still hangs at busybox pid 1.
 
 Flash (destroys the target stick):
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,17 @@ On a machine that already runs `linux-asahi`:
 Writes `release/omarchy-mac-iso-usb/omarchy-mac-usb.img` — GPT with a FAT32
 ESP labelled `OMARCHYISO` (standalone GRUB, this host's `linux-asahi`,
 initramfs with `dwc3-apple`) and a btrfs payload labelled `OMARCHYLIVE`
-(subvol `@`, tiny busybox `/sbin/init` until S3). No root required. Copying
-files onto an existing FAT stick is not enough — the payload is its own
-partition.
+(subvol `@`, tiny busybox `/sbin/init`). No root required. Copying files
+onto an existing FAT stick is not enough — the payload is its own partition.
+
+S3 systemd userspace (not the Omarchy desktop) — needs root, `arch-install-scripts`:
+
+```
+sudo ./bin/omarchy-mac-iso-make --usb --rootfs
+```
+
+Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1.
+Default `--usb` without `--rootfs` still hangs at busybox pid 1.
 
 Flash (destroys the target stick):
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ sudo ./bin/omarchy-mac-iso-make --usb --rootfs
 ```
 
 Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1
-(proven on an M2 Max, 2026-08-23). `--rootfs` now includes `linux-asahi`
-(modules), NetworkManager, and `iwd`; vendor firmware is copied from the
-internal ESP at boot. Use `nmtui` or `iwctl`. Default `--usb` without
+(proven on an M2 Max, 2026-08-23). `--rootfs` includes kernel modules,
+NetworkManager, and `iwd`; vendor firmware is copied from the internal ESP
+at boot. Wi-Fi: open `nmtui`, Rescan if wlan is missing, then Activate
+(PSK works there after a scan; `nmcli device wifi connect … password`
+can still fail with "secrets not provided"). Default `--usb` without
 `--rootfs` still hangs at busybox pid 1.
 
 Flash (destroys the target stick):

--- a/bin/omarchy-mac-iso-make
+++ b/bin/omarchy-mac-iso-make
@@ -22,39 +22,57 @@ check_deps() {
 
 usage() {
     cat <<'EOF'
-Usage: omarchy-mac-iso-make [--usb]
+Usage: omarchy-mac-iso-make [--usb] [--rootfs]
 
 Default: M0 QEMU artifact (Alpine linux-virt kernel + initramfs) into
 release/omarchy-mac-iso-arm64/. Does not boot a Mac.
 
 --usb: native Apple Silicon GPT image (linux-asahi, GRUB ESP, btrfs
 payload) into release/omarchy-mac-iso-usb/. Requires linux-asahi on the host.
+Tiny busybox pid 1, unprivileged.
+
+--usb --rootfs: pacstrap Arch `base` (systemd) into the payload instead of
+busybox. Needs root. Not the Omarchy desktop.
 EOF
 }
 
 main() {
     local mode="qemu"
-    case "${1:-}" in
-        -h|--help)
-            usage
-            exit 0
-            ;;
-        --usb)
-            mode="usb"
-            shift
-            [[ "${1:-}" == "" ]] || fail "unexpected argument: $1"
-            ;;
-        "")
-            ;;
-        *)
-            fail "unexpected argument: $1"
-            ;;
-    esac
+    local rootfs=0
+    while (( $# > 0 )); do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            --usb)
+                mode="usb"
+                shift
+                ;;
+            --rootfs)
+                rootfs=1
+                shift
+                ;;
+            *)
+                fail "unexpected argument: $1"
+                ;;
+        esac
+    done
+
+    if (( rootfs == 1 )) && [[ $mode != usb ]]; then
+        fail "--rootfs requires --usb"
+    fi
 
     if [[ "${mode}" == "usb" ]]; then
         log "Checking USB-image build dependencies"
         local usb_dir="${repo_root}/release/omarchy-mac-iso-usb"
         rm -rf "${usb_dir}"
+        if (( rootfs == 1 )); then
+            (( EUID == 0 )) || fail "--usb --rootfs needs root (pacstrap)"
+            export OMARCHY_USB_ROOTFS=1
+        else
+            unset OMARCHY_USB_ROOTFS || true
+        fi
         "${builder_dir}/build-usb-image.sh" "${usb_dir}"
         log "Build complete"
         return 0

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -85,10 +85,9 @@ printf 'LANG=C.UTF-8\n' >"$mnt/etc/locale.conf"
 : >"$mnt/etc/machine-id"
 
 install -d "$mnt/etc/NetworkManager/conf.d"
-cat >"$mnt/etc/NetworkManager/conf.d/wifi_backend.conf" <<'EOF'
-[device]
-wifi.backend=iwd
-EOF
+install -m644 "$repo_root/configs/usb/rootfs/nm-live.conf" \
+  "$mnt/etc/NetworkManager/conf.d/nm-live.conf"
+install -d -m700 "$mnt/etc/NetworkManager/system-connections"
 
 systemctl --root="$mnt" enable omarchy-mac-usb-ready.service
 systemctl --root="$mnt" enable NetworkManager.service

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -47,8 +47,11 @@ mkfs.btrfs -q -L OMARCHYLIVE --csum crc32c \
 loop="$(losetup -f --show "$out")"
 mount -o subvol=@ "$loop" "$mnt"
 
-log "pacstrap base (systemd, no kernel — live kernel is on the ESP)"
-pacstrap -c "$mnt" base
+# Kernel is still loaded from the ESP; linux-asahi here is for modules
+# (brcmfmac, cdc_ether, …) after switch_root. Firmware is copied from the
+# initramfs at boot (internal ESP), not baked in.
+log "pacstrap base linux-asahi networkmanager iwd"
+pacstrap -c "$mnt" base linux-asahi networkmanager iwd asahi-scripts
 
 install -m644 "$repo_root/configs/usb/rootfs/issue" "$mnt/etc/issue"
 install -d "$mnt/etc/systemd/system"
@@ -63,7 +66,14 @@ printf 'LANG=C.UTF-8\n' >"$mnt/etc/locale.conf"
 : >"$mnt/etc/fstab"
 : >"$mnt/etc/machine-id"
 
+install -d "$mnt/etc/NetworkManager/conf.d"
+cat >"$mnt/etc/NetworkManager/conf.d/wifi_backend.conf" <<'EOF'
+[device]
+wifi.backend=iwd
+EOF
+
 systemctl --root="$mnt" enable omarchy-mac-usb-ready.service
+systemctl --root="$mnt" enable NetworkManager.service
 systemctl --root="$mnt" set-default multi-user.target
 
 [[ -x $mnt/sbin/init || -L $mnt/sbin/init ]] || fail "pacstrap did not install /sbin/init"

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Usage: build-rootfs.sh <out-payload.img>
+# Pacstrap Arch Linux ARM `base` onto btrfs @ (label OMARCHYLIVE).
+# Needs root. This is S3: systemd userspace, not the Omarchy desktop.
+set -euo pipefail
+
+out="$1"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+payload_bytes=${OMARCHY_USB_PAYLOAD_BYTES:-$((2 * 1024 * 1024 * 1024))}
+
+log() { printf '==> %s\n' "$*" >&2; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+(( EUID == 0 )) || fail "build-rootfs.sh needs root (pacstrap + mount)"
+command -v pacstrap >/dev/null || fail "pacstrap not found — pacman -S arch-install-scripts"
+command -v mkfs.btrfs >/dev/null || fail "need btrfs-progs"
+command -v losetup >/dev/null || fail "need losetup"
+
+loop=""
+mnt=""
+cleanup() {
+  if [[ -n $mnt ]]; then
+    umount "$mnt" 2>/dev/null || true
+  fi
+  if [[ -n $loop ]]; then
+    losetup -d "$loop" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+work="$(mktemp -d)"
+mnt="$work/mnt"
+mkdir -p "$mnt" "$work/root/@" "$work/root/@home" "$work/root/@log"
+printf 'omarchy-mac-live-ok rootfs %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  > "$work/root/@/omarchy-mac-live-ok"
+
+log "Creating ${payload_bytes} byte btrfs payload"
+rm -f "$out"
+truncate -s "$payload_bytes" "$out"
+mkfs.btrfs -q -L OMARCHYLIVE --csum crc32c \
+  --rootdir "$work/root" \
+  --subvol default:@ \
+  --subvol rw:@home \
+  --subvol rw:@log \
+  "$out"
+
+loop="$(losetup -f --show "$out")"
+mount -o subvol=@ "$loop" "$mnt"
+
+log "pacstrap base (systemd, no kernel — live kernel is on the ESP)"
+pacstrap -c "$mnt" base
+
+install -m644 "$repo_root/configs/usb/rootfs/issue" "$mnt/etc/issue"
+install -d "$mnt/etc/systemd/system"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-usb-ready.service" \
+  "$mnt/etc/systemd/system/omarchy-mac-usb-ready.service"
+install -d "$mnt/etc/systemd/system/getty@tty1.service.d"
+install -m644 "$repo_root/configs/usb/rootfs/getty-autologin.conf" \
+  "$mnt/etc/systemd/system/getty@tty1.service.d/autologin.conf"
+
+printf 'omarchy-mac-live\n' >"$mnt/etc/hostname"
+printf 'LANG=C.UTF-8\n' >"$mnt/etc/locale.conf"
+: >"$mnt/etc/fstab"
+: >"$mnt/etc/machine-id"
+
+systemctl --root="$mnt" enable omarchy-mac-usb-ready.service
+systemctl --root="$mnt" set-default multi-user.target
+
+[[ -x $mnt/sbin/init || -L $mnt/sbin/init ]] || fail "pacstrap did not install /sbin/init"
+log "payload used $(du -sh "$mnt" | cut -f1) on the @ subvolume"
+
+sync
+umount "$mnt"
+mnt=""
+losetup -d "$loop"
+loop=""
+trap - EXIT

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -20,6 +20,8 @@ loop=""
 mnt=""
 cleanup() {
   if [[ -n $mnt ]]; then
+    umount "$mnt/boot" 2>/dev/null || true
+    umount "$mnt/run" 2>/dev/null || true
     umount "$mnt" 2>/dev/null || true
   fi
   if [[ -n $loop ]]; then
@@ -47,11 +49,27 @@ mkfs.btrfs -q -L OMARCHYLIVE --csum crc32c \
 loop="$(losetup -f --show "$out")"
 mount -o subvol=@ "$loop" "$mnt"
 
-# Kernel is still loaded from the ESP; linux-asahi here is for modules
-# (brcmfmac, cdc_ether, …) after switch_root. Firmware is copied from the
-# initramfs at boot (internal ESP), not baked in.
-log "pacstrap base linux-asahi networkmanager iwd"
-pacstrap -c "$mnt" base linux-asahi networkmanager iwd asahi-scripts
+# Isolate the chroot so alpm hooks cannot mount the host ESP
+# (/run/.system-efi → nvme0n1p4). Do not pacstrap asahi-scripts or
+# linux-asahi: update-m1n1 is for the installed system, and the live
+# kernel is already on the USB ESP. Copy this host's modules so they
+# match that kernel (brcmfmac, cdc_ether, …). Firmware is copied from
+# the initramfs at boot.
+mkdir -p "$mnt/run" "$mnt/boot"
+mount -t tmpfs tmpfs "$mnt/run"
+mount -t tmpfs tmpfs "$mnt/boot"
+
+log "pacstrap base networkmanager iwd"
+pacstrap -c "$mnt" base networkmanager iwd
+
+umount "$mnt/boot"
+umount "$mnt/run"
+
+kver=$(uname -r)
+log "Copying host modules $kver (match ESP vmlinuz)"
+mkdir -p "$mnt/usr/lib/modules"
+cp -a "/usr/lib/modules/$kver" "$mnt/usr/lib/modules/"
+[[ -d $mnt/usr/lib/modules/$kver ]] || fail "failed to copy modules for $kver"
 
 install -m644 "$repo_root/configs/usb/rootfs/issue" "$mnt/etc/issue"
 install -d "$mnt/etc/systemd/system"

--- a/builder/build-usb-image.sh
+++ b/builder/build-usb-image.sh
@@ -34,7 +34,11 @@ trap cleanup EXIT
 mkdir -p "$work" "$out_dir"
 
 log "Building btrfs payload (OMARCHYLIVE)"
-"$repo_root/builder/build-usb-rootimg.sh" "$work/payload.img"
+if [[ ${OMARCHY_USB_ROOTFS:-} == 1 ]]; then
+  "$repo_root/builder/build-rootfs.sh" "$work/payload.img"
+else
+  "$repo_root/builder/build-usb-rootimg.sh" "$work/payload.img"
+fi
 payload_bytes=$(stat -c %s "$work/payload.img")
 payload_mib=$(( (payload_bytes + 1024 * 1024 - 1) / (1024 * 1024) ))
 
@@ -111,6 +115,8 @@ cp /boot/vmlinuz-linux-asahi "$out_dir/vmlinuz-linux-asahi"
 cp "$repo_root/configs/usb/grub.cfg" "$out_dir/grub.cfg"
 
 git_ref="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+payload_kind="busybox pid 1"
+[[ ${OMARCHY_USB_ROOTFS:-} == 1 ]] && payload_kind="systemd base (pacstrap)"
 cat > "$out_dir/BUILD_INFO" <<EOF
 artifact: omarchy-mac-usb
 built_from_ref: $git_ref
@@ -118,7 +124,7 @@ kernel: linux-asahi $kver
 contract: GPT disk image, FAT32 ESP labelled OMARCHYISO + btrfs payload labelled OMARCHYLIVE (subvol=@)
   EFI/BOOT/BOOTAA64.EFI (grub-mkstandalone)
   /vmlinuz-linux-asahi + /initramfs-omarchy-usb.img on the ESP
-  payload partition is the live root (not a root.img file on FAT)
+  payload: $payload_kind
 flash: dd if=omarchy-mac-usb.img of=/dev/sdX bs=4M status=progress conv=fsync
 EOF
 

--- a/configs/usb-initcpio/hooks/omarchy-usb-live
+++ b/configs/usb-initcpio/hooks/omarchy-usb-live
@@ -64,10 +64,10 @@ run_hook() {
 
   echo "writable overlay" >"$NEW_ROOT/omarchy-mac-overlay-write"
 
-  if [ ! -x "$NEW_ROOT/sbin/init" ] || [ -L "$NEW_ROOT/sbin/init" ]; then
-    hang "omarchy-usb-live: /sbin/init missing or is a symlink"
+  if [ ! -x "$NEW_ROOT/sbin/init" ]; then
+    hang "omarchy-usb-live: /sbin/init missing"
   fi
-  if [ -L "$NEW_ROOT/bin/busybox" ]; then
+  if [ -e "$NEW_ROOT/bin/busybox" ] && [ -L "$NEW_ROOT/bin/busybox" ]; then
     hang "omarchy-usb-live: busybox is a symlink (switch_root would ENOENT)"
   fi
 

--- a/configs/usb-initcpio/hooks/omarchy-usb-live
+++ b/configs/usb-initcpio/hooks/omarchy-usb-live
@@ -74,6 +74,17 @@ run_hook() {
   echo "==> OMARCHY_MAC_USB_READY" >/dev/console
   echo "==> OMARCHY_MAC_USB_READY payload=$payload_dev marker=$(cat "$LIVE_MOUNT/$MARKER" 2>/dev/null)"
 
+  # Asahi vendor firmware was extracted from the internal ESP by the asahi
+  # hook. Carry it across switch_root so brcmfmac can associate in userspace.
+  if [ -d /lib/firmware/vendor ]; then
+    mkdir -p "$NEW_ROOT/lib/firmware/vendor"
+    cp -a /lib/firmware/vendor/. "$NEW_ROOT/lib/firmware/vendor/"
+  fi
+  if [ -d /vendorfw ]; then
+    mkdir -p "$NEW_ROOT/vendorfw"
+    cp -a /vendorfw/. "$NEW_ROOT/vendorfw/"
+  fi
+
   mkdir -p "$NEW_ROOT/proc" "$NEW_ROOT/sys" "$NEW_ROOT/dev" "$NEW_ROOT/run"
   mount --move /proc "$NEW_ROOT/proc" 2>/dev/null || mount -t proc proc "$NEW_ROOT/proc"
   mount --move /sys "$NEW_ROOT/sys" 2>/dev/null || mount -t sysfs sys "$NEW_ROOT/sys"

--- a/configs/usb/rootfs/getty-autologin.conf
+++ b/configs/usb/rootfs/getty-autologin.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear %I $TERM

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -1,2 +1,4 @@
 Omarchy Mac live USB (systemd). Not the installer yet.
+Network: nmtui  or  iwctl station wlan0 scan
+
 

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -1,0 +1,2 @@
+Omarchy Mac live USB (systemd). Not the installer yet.
+

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -1,6 +1,6 @@
 Omarchy Mac live USB (systemd). Not the installer yet.
-Wi-Fi:  nmcli device wifi connect 'SSID' password 'PSK'
-  (nmtui Activate on this console often drops the PSK; nmcli stores it)
-USB:    nmcli device connect enu1
+Wi-Fi: nmtui — Rescan if the list is empty, then Activate.
+  (nmcli … password can still fail with "secrets not provided" on iwd)
+USB:   nmcli device connect enu1
 
 

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -1,4 +1,6 @@
 Omarchy Mac live USB (systemd). Not the installer yet.
-Network: nmtui  or  iwctl station wlan0 scan
+Wi-Fi:  nmcli device wifi connect 'SSID' password 'PSK'
+  (nmtui Activate on this console often drops the PSK; nmcli stores it)
+USB:    nmcli device connect enu1
 
 

--- a/configs/usb/rootfs/nm-live.conf
+++ b/configs/usb/rootfs/nm-live.conf
@@ -1,0 +1,7 @@
+[main]
+auth-polkit=false
+dhcp=internal
+plugins=keyfile
+
+[device]
+wifi.backend=iwd

--- a/configs/usb/rootfs/omarchy-mac-usb-ready.service
+++ b/configs/usb/rootfs/omarchy-mac-usb-ready.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Announce Omarchy Mac USB systemd userspace
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/bash -c 'echo "==> OMARCHY_MAC_USB_SYSTEMD pid=$$" >/dev/console; echo "==> OMARCHY_MAC_USB_SYSTEMD pid=$$"'
+
+[Install]
+WantedBy=multi-user.target

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -307,8 +307,9 @@ the busybox tree on `@` with Arch `base` / systemd.
 `builder/build-rootfs.sh` via `./bin/omarchy-mac-iso-make --usb --rootfs`
 (needs root, `arch-install-scripts`). First cut **proven on metal
 2026-08-23**: pacstrap Arch `base` onto `@`, `switch_root` into systemd,
-autologin root shell. No NetworkManager/`nmtui`/`iwd` yet. Not the
-Omarchy desktop. Then Asahi packages → the fork's package set →
+autologin root shell, `nmtui` + brcmfmac scan. PSK via nmtui Activate
+does not reach iwd on this getty; use `nmcli device wifi connect`.
+Not the Omarchy desktop. Then Asahi packages → the fork's package set →
 provisioning with hardware-specific work that is *not* per-machine done at
 build time (audio stack, `fnmode`, notch modprobe) → defer keymap / user /
 hostname / anything that reads this panel to first boot or the installer →
@@ -351,9 +352,12 @@ GitHub Releases vs R2 vs split assets.
    `OMARCHY_MAC_USB_READY payload=/dev/sda2`, then
    `OMARCHY_MAC_USB_USERSPACE pid=1` with marker and overlay write.
    Remaining: Wi-Fi in the live env.
-   `--usb --rootfs` on metal 2026-08-23: systemd userspace and a root
-   shell. Next: NetworkManager/`iwd` plus linux-asahi modules and vendor
-   firmware carried across `switch_root`.
+   `--usb --rootfs` on metal 2026-08-23: systemd userspace, `nmtui`,
+   brcmfmac scan (SSIDs listed), Pixel USB tether as `enu1`/`cdc_ncm`.
+   nmtui Activate failed with "secrets were required but not provided"
+   even after entering the PSK (iwd backend on a getty, no secrets
+   agent). USB gadget was UP with no DHCPv4. Next: `auth-polkit=false`
+   and `nmcli device wifi connect`.
 2. `./bin/omarchy-mac-iso-make --usb` produces a GPT ESP + payload image on
    this Mac and boots; `test/unit` green; `bash -n` over every script.
    Container still open.

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -304,7 +304,10 @@ the busybox tree on `@`.
 
 ### S3 — The rootfs artifact
 
-`builder/build-rootfs.sh`: pacstrap → Asahi packages → the fork's package set →
+`builder/build-rootfs.sh` via `./bin/omarchy-mac-iso-make --usb --rootfs`
+(needs root, `arch-install-scripts`). First cut: pacstrap Arch `base`
+(systemd, no kernel — live kernel stays on the ESP) onto `@`. Not the
+Omarchy desktop. Then Asahi packages → the fork's package set →
 provisioning with hardware-specific work that is *not* per-machine done at
 build time (audio stack, `fnmode`, notch modprobe) → defer keymap / user /
 hostname / anything that reads this panel to first boot or the installer →

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -299,14 +299,15 @@ Native `./bin/omarchy-mac-iso-make --usb` on this Mac produces a GPT image
 (ESP + btrfs payload) that boots on metal (2026-08-23, payload partition
 not a `root.img` loop). Then the same builder in
 `docker --platform linux/arm64` from Arch Linux ARM with `[asahi-alarm]`
-and `[omarchy-aarch64]`, then CI. `builder/build-rootfs.sh` (S3) will replace
-the busybox tree on `@`.
+and `[omarchy-aarch64]`, then CI. `builder/build-rootfs.sh` (S3) replaces
+the busybox tree on `@` with Arch `base` / systemd.
 
 ### S3 — The rootfs artifact
 
 `builder/build-rootfs.sh` via `./bin/omarchy-mac-iso-make --usb --rootfs`
-(needs root, `arch-install-scripts`). First cut: pacstrap Arch `base`
-(systemd, no kernel — live kernel stays on the ESP) onto `@`. Not the
+(needs root, `arch-install-scripts`). First cut **proven on metal
+2026-08-23**: pacstrap Arch `base` onto `@`, `switch_root` into systemd,
+autologin root shell. No NetworkManager/`nmtui`/`iwd` yet. Not the
 Omarchy desktop. Then Asahi packages → the fork's package set →
 provisioning with hardware-specific work that is *not* per-machine done at
 build time (audio stack, `fnmode`, notch modprobe) → defer keymap / user /
@@ -350,6 +351,9 @@ GitHub Releases vs R2 vs split assets.
    `OMARCHY_MAC_USB_READY payload=/dev/sda2`, then
    `OMARCHY_MAC_USB_USERSPACE pid=1` with marker and overlay write.
    Remaining: Wi-Fi in the live env.
+   `--usb --rootfs` on metal 2026-08-23: systemd userspace and a root
+   shell. `base` has no NetworkManager/`nmtui`; USB tethering is also
+   not in this payload.
 2. `./bin/omarchy-mac-iso-make --usb` produces a GPT ESP + payload image on
    this Mac and boots; `test/unit` green; `bash -n` over every script.
    Container still open.

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -45,7 +45,8 @@ Spikes live in `~/code/omarchy-mac-iso-spike/`. Reports:
 | Os-package zip, from source | Raw zip: `esp/` tree + `root.img` (size multiple of 4 KiB). Optional `boot.img`, `icon`. `fdcopy` onto `/dev/rdiskNsM`. No sparse format. `INSTALLER_DATA` / `REPO_BASE` is the supported third-party hook. `supported_fw` filters IPSW versions (`12.3`, `12.3.1`, `13.5`, `14.8.3`), not kernel features. |
 | Alarm size precedent is **Minimal**, not a desktop | Alarm Minimal `root.img` is 2,209,614,225 bytes; Desktop is 12.7 GB in a **1.88 GiB** zip. This machine's `@` subvolume is ~13 GB (`du -sx /` does not cross `@home`). A full Omarchy image will look like Desktop, not Minimal. GitHub Releases' 2 GiB per-file cap is tight. |
 
-Not yet proven on the stick: Wi-Fi association in the live environment, or an install `dd` onto a target disk. Overlay + `switch_root` into busybox pid 1 is done (2026-08-23).
+Not yet proven on the stick: an install `dd` onto a target disk. Overlay +
+`switch_root`, systemd userspace, and Wi-Fi association are done (2026-08-23).
 
 ## Architecture: one rootfs, two front doors
 
@@ -307,9 +308,10 @@ the busybox tree on `@` with Arch `base` / systemd.
 `builder/build-rootfs.sh` via `./bin/omarchy-mac-iso-make --usb --rootfs`
 (needs root, `arch-install-scripts`). First cut **proven on metal
 2026-08-23**: pacstrap Arch `base` onto `@`, `switch_root` into systemd,
-autologin root shell, `nmtui` + brcmfmac scan. PSK via nmtui Activate
-does not reach iwd on this getty; use `nmcli device wifi connect`.
-Not the Omarchy desktop. Then Asahi packages → the fork's package set →
+autologin root shell, `nmtui` + brcmfmac scan, then `ping www.google.com`.
+wlan0 is missing until nmtui Rescan; `nmcli … password` can still fail
+secrets-not-provided on iwd. Not the Omarchy desktop. Then Asahi packages →
+the fork's package set →
 provisioning with hardware-specific work that is *not* per-machine done at
 build time (audio stack, `fnmode`, notch modprobe) → defer keymap / user /
 hostname / anything that reads this panel to first boot or the installer →
@@ -351,13 +353,10 @@ GitHub Releases vs R2 vs split assets.
    2026-08-23: btrfs `OMARCHYLIVE` on `/dev/sda2`,
    `OMARCHY_MAC_USB_READY payload=/dev/sda2`, then
    `OMARCHY_MAC_USB_USERSPACE pid=1` with marker and overlay write.
-   Remaining: Wi-Fi in the live env.
-   `--usb --rootfs` on metal 2026-08-23: systemd userspace, `nmtui`,
-   brcmfmac scan (SSIDs listed), Pixel USB tether as `enu1`/`cdc_ncm`.
-   nmtui Activate failed with "secrets were required but not provided"
-   even after entering the PSK (iwd backend on a getty, no secrets
-   agent). USB gadget was UP with no DHCPv4. Next: `auth-polkit=false`
-   and `nmcli device wifi connect`.
+   `--usb --rootfs` Wi-Fi on metal 2026-08-23: nmtui Rescan then Activate
+   associated to flintstone; `ping www.google.com` succeeded. `nmcli
+   device wifi connect … password` still failed secrets-not-provided
+   (`brcmf join_pref -52`). Pixel USB tether enumerates as `enu1`/`cdc_ncm`.
 2. `./bin/omarchy-mac-iso-make --usb` produces a GPT ESP + payload image on
    this Mac and boots; `test/unit` green; `bash -n` over every script.
    Container still open.

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -352,8 +352,8 @@ GitHub Releases vs R2 vs split assets.
    `OMARCHY_MAC_USB_USERSPACE pid=1` with marker and overlay write.
    Remaining: Wi-Fi in the live env.
    `--usb --rootfs` on metal 2026-08-23: systemd userspace and a root
-   shell. `base` has no NetworkManager/`nmtui`; USB tethering is also
-   not in this payload.
+   shell. Next: NetworkManager/`iwd` plus linux-asahi modules and vendor
+   firmware carried across `switch_root`.
 2. `./bin/omarchy-mac-iso-make --usb` produces a GPT ESP + payload image on
    this Mac and boots; `test/unit` green; `bash -n` over every script.
    Container still open.

--- a/test/unit
+++ b/test/unit
@@ -36,6 +36,10 @@ check "KERNEL_PKG_SHA256 is 64 hex chars" bash -c "[[ '${KERNEL_PKG_SHA256}' =~ 
 check "omarchy-mac-iso-make --help works offline" "${repo_root}/bin/omarchy-mac-iso-make" --help
 check "omarchy-mac-iso-make --help mentions --usb" \
   grep -q -- '--usb' <("${repo_root}/bin/omarchy-mac-iso-make" --help)
+check "omarchy-mac-iso-make --help mentions --rootfs" \
+  grep -q -- '--rootfs' <("${repo_root}/bin/omarchy-mac-iso-make" --help)
+check "omarchy-mac-iso-make --rootfs without --usb fails" \
+  bash -c '! '"${repo_root}"'/bin/omarchy-mac-iso-make --rootfs'
 check "omarchy-mac-iso-boot --help works offline" "${repo_root}/bin/omarchy-mac-iso-boot" --help
 check "usb grub.cfg finds initramfs-omarchy-usb.img" \
   grep -q initramfs-omarchy-usb.img "${repo_root}/configs/usb/grub.cfg"

--- a/test/unit
+++ b/test/unit
@@ -58,6 +58,8 @@ check "usb image builds a payload partition" grep -q 'mkpart payload' \
   "${repo_root}/builder/build-usb-image.sh"
 check "rootfs pacstraps networkmanager and iwd" grep -q networkmanager \
   "${repo_root}/builder/build-rootfs.sh"
+check "NM live conf disables polkit auth" grep -q 'auth-polkit=false' \
+  "${repo_root}/configs/usb/rootfs/nm-live.conf"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 

--- a/test/unit
+++ b/test/unit
@@ -56,6 +56,10 @@ check "usb rootimg copies initcpio busybox" grep -q /usr/lib/initcpio/busybox \
   "${repo_root}/builder/build-usb-rootimg.sh"
 check "usb image builds a payload partition" grep -q 'mkpart payload' \
   "${repo_root}/builder/build-usb-image.sh"
+check "rootfs pacstraps networkmanager and iwd" grep -q networkmanager \
+  "${repo_root}/builder/build-rootfs.sh"
+check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
+  "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 
 if (( failures > 0 )); then
     echo "${failures} failure(s)"


### PR DESCRIPTION
## Summary

`--usb --rootfs` pacstraps Arch `base` onto the btrfs `@` payload (systemd, not the Omarchy desktop). Default `--usb` stays the unprivileged busybox image.

Proven on an M2 Max: autologin root shell, `nmtui`, brcmfmac scan, then Wi-Fi association and `ping www.google.com`. Pixel USB tether enumerates as `enu1`.

## Notes from metal

- Do not pacstrap `asahi-scripts` into the live root — its alpm hooks bind-mounted this machine's ESP at `/run/.system-efi` (`boot.bin` was not rewritten). `/boot` and `/run` in the chroot are tmpfs; kernel modules are copied from the build host so they match the ESP vmlinuz.
- wlan0 is missing until nmtui **Rescan**. `nmcli device wifi connect … password` can still fail with "secrets not provided" on the iwd backend; nmtui Activate after a rescan is what worked.
- Cold start, then `load usb 0:1` / `bootefi` as in the README.