### PR TITLE
Live USB: Asahi mesa, audio, gum, and fnmode/notch

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ sudo ./bin/omarchy-mac-iso-make --usb --rootfs
 ```
 
 Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1
-(proven on an M2 Max, 2026-08-23). `--rootfs` includes kernel modules,
-NetworkManager, and `iwd`; vendor firmware is copied from the internal ESP
-at boot. Wi-Fi: open `nmtui`, Rescan if wlan is missing, then Activate
+(proven on an M2 Max, 2026-08-23). `--rootfs` includes kernel modules, NetworkManager, `iwd`, Asahi mesa,
+asahi-audio, speakersafetyd, gum, `hid_apple fnmode=1`, and
+`appledrm show_notch=1`. Vendor firmware is copied from the internal ESP
+at boot. Still not the Omarchy desktop. Wi-Fi: open `nmtui`, Rescan if wlan is missing, then Activate
 (PSK works there after a scan; `nmcli device wifi connect … password`
 can still fail with "secrets not provided"). Default `--usb` without
 `--rootfs` still hangs at busybox pid 1.

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1
 (proven on an M2 Max, 2026-08-23). `--rootfs` includes kernel modules, NetworkManager, `iwd`, Asahi mesa,
 asahi-audio, speakersafetyd, gum, `hid_apple fnmode=1`, and
 `appledrm show_notch=1`. Vendor firmware is copied from the internal ESP
-at boot. Still not the Omarchy desktop. Wi-Fi: open `nmtui`, Rescan if wlan is missing, then Activate
-(PSK works there after a scan; `nmcli device wifi connect … password`
-can still fail with "secrets not provided"). Default `--usb` without
-`--rootfs` still hangs at busybox pid 1.
+at boot. Still not the Omarchy desktop. Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
+`nmcli device wifi connect 'SSID' password 'PSK'` (nmcli failed before a
+scan, succeeded after). `gum --version` and `fnmode=1` proven on metal.
+Default `--usb` without `--rootfs` still hangs at busybox pid 1.
 
 Flash (destroys the target stick):
 

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 out="$1"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-payload_bytes=${OMARCHY_USB_PAYLOAD_BYTES:-$((2 * 1024 * 1024 * 1024))}
+payload_bytes=${OMARCHY_USB_PAYLOAD_BYTES:-$((3 * 1024 * 1024 * 1024))}
 
 log() { printf '==> %s\n' "$*" >&2; }
 fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
@@ -59,8 +59,9 @@ mkdir -p "$mnt/run" "$mnt/boot"
 mount -t tmpfs tmpfs "$mnt/run"
 mount -t tmpfs tmpfs "$mnt/boot"
 
-log "pacstrap base networkmanager iwd"
-pacstrap -c "$mnt" base networkmanager iwd
+log "pacstrap base networkmanager iwd mesa asahi-audio gum"
+pacstrap -c "$mnt" base networkmanager iwd mesa asahi-audio \
+  alsa-ucm-conf-asahi speakersafetyd pipewire-pulse gum
 
 umount "$mnt/boot"
 umount "$mnt/run"
@@ -88,9 +89,19 @@ install -d "$mnt/etc/NetworkManager/conf.d"
 install -m644 "$repo_root/configs/usb/rootfs/nm-live.conf" \
   "$mnt/etc/NetworkManager/conf.d/nm-live.conf"
 install -d -m700 "$mnt/etc/NetworkManager/system-connections"
+install -d "$mnt/etc/modprobe.d"
+install -m644 "$repo_root/configs/usb/modprobe.d/hid_apple.conf" \
+  "$mnt/etc/modprobe.d/hid_apple.conf"
+install -m644 "$repo_root/configs/usb/modprobe.d/asahi-notch.conf" \
+  "$mnt/etc/modprobe.d/asahi-notch.conf"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-asahi-hw.service" \
+  "$mnt/etc/systemd/system/omarchy-mac-asahi-hw.service"
 
 systemctl --root="$mnt" enable omarchy-mac-usb-ready.service
+systemctl --root="$mnt" enable omarchy-mac-asahi-hw.service
 systemctl --root="$mnt" enable NetworkManager.service
+systemctl --root="$mnt" enable speakersafetyd.service
+systemctl --root="$mnt" --global enable pipewire.socket pipewire-pulse.socket wireplumber.service 2>/dev/null || true
 systemctl --root="$mnt" set-default multi-user.target
 
 [[ -x $mnt/sbin/init || -L $mnt/sbin/init ]] || fail "pacstrap did not install /sbin/init"

--- a/configs/usb-initcpio/install/omarchy-usb-live
+++ b/configs/usb-initcpio/install/omarchy-usb-live
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 build() {
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   add_binary /usr/bin/lsblk
   add_binary /usr/bin/lsmod
   add_binary /usr/bin/dmesg
@@ -9,6 +11,8 @@ build() {
   add_binary /usr/bin/umount
   add_binary /usr/bin/switch_root
   add_full_dir /usr/share/asahi-scripts
+  add_file "$here/../../usb/modprobe.d/hid_apple.conf" /etc/modprobe.d/hid_apple.conf
+  add_file "$here/../../usb/modprobe.d/asahi-notch.conf" /etc/modprobe.d/asahi-notch.conf
   add_runscript
 }
 

--- a/configs/usb/modprobe.d/asahi-notch.conf
+++ b/configs/usb/modprobe.d/asahi-notch.conf
@@ -1,0 +1,1 @@
+options appledrm show_notch=1

--- a/configs/usb/modprobe.d/hid_apple.conf
+++ b/configs/usb/modprobe.d/hid_apple.conf
@@ -1,0 +1,1 @@
+options hid_apple fnmode=1

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -1,5 +1,6 @@
 Omarchy Mac live USB (systemd). Not the installer yet.
-Wi-Fi: nmtui — Rescan if the list is empty, then Activate.
+Wi-Fi: nmtui Rescan until SSIDs appear, then
+       nmtui Activate  or  nmcli device wifi connect 'SSID' password 'PSK'
 USB:   nmcli device connect enu1
 Check: cat /sys/module/hid_apple/parameters/fnmode   (want 1)
        gum --version

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -1,6 +1,7 @@
 Omarchy Mac live USB (systemd). Not the installer yet.
 Wi-Fi: nmtui — Rescan if the list is empty, then Activate.
-  (nmcli … password can still fail with "secrets not provided" on iwd)
 USB:   nmcli device connect enu1
+Check: cat /sys/module/hid_apple/parameters/fnmode   (want 1)
+       gum --version
 
 

--- a/configs/usb/rootfs/omarchy-mac-asahi-hw.service
+++ b/configs/usb/rootfs/omarchy-mac-asahi-hw.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Set Asahi hid_apple fnmode and appledrm show_notch
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/bash -c 'echo 1 >/sys/module/hid_apple/parameters/fnmode 2>/dev/null; echo 1 >/sys/module/appledrm/parameters/show_notch 2>/dev/null; true'
+
+[Install]
+WantedBy=multi-user.target

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -310,8 +310,9 @@ the busybox tree on `@` with Arch `base` / systemd.
 2026-08-23**: pacstrap Arch `base` onto `@`, `switch_root` into systemd,
 autologin root shell, `nmtui` + brcmfmac scan, then `ping www.google.com`.
 wlan0 is missing until nmtui Rescan; `nmcli … password` can still fail
-secrets-not-provided on iwd. Not the Omarchy desktop. Then Asahi packages →
-the fork's package set →
+secrets-not-provided on iwd. Not the Omarchy desktop. Asahi mesa / asahi-audio / speakersafetyd / gum
+and `fnmode=1` / `show_notch=1` go in this payload (not `asahi-scripts`).
+Then the fork's package set →
 provisioning with hardware-specific work that is *not* per-machine done at
 build time (audio stack, `fnmode`, notch modprobe) → defer keymap / user /
 hostname / anything that reads this panel to first boot or the installer →

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -309,9 +309,11 @@ the busybox tree on `@` with Arch `base` / systemd.
 (needs root, `arch-install-scripts`). First cut **proven on metal
 2026-08-23**: pacstrap Arch `base` onto `@`, `switch_root` into systemd,
 autologin root shell, `nmtui` + brcmfmac scan, then `ping www.google.com`.
-wlan0 is missing until nmtui Rescan; `nmcli … password` can still fail
-secrets-not-provided on iwd. Not the Omarchy desktop. Asahi mesa / asahi-audio / speakersafetyd / gum
-and `fnmode=1` / `show_notch=1` go in this payload (not `asahi-scripts`).
+wlan0 is missing until nmtui Rescan; after that both nmtui Activate and
+`nmcli … password` have worked. `gum` 0.17.0 and `hid_apple fnmode=1`
+proven on metal. Not the Omarchy desktop. Asahi mesa / asahi-audio /
+speakersafetyd / gum and `fnmode=1` / `show_notch=1` go in this payload
+(not `asahi-scripts`).
 Then the fork's package set →
 provisioning with hardware-specific work that is *not* per-machine done at
 build time (audio stack, `fnmode`, notch modprobe) → defer keymap / user /
@@ -354,10 +356,10 @@ GitHub Releases vs R2 vs split assets.
    2026-08-23: btrfs `OMARCHYLIVE` on `/dev/sda2`,
    `OMARCHY_MAC_USB_READY payload=/dev/sda2`, then
    `OMARCHY_MAC_USB_USERSPACE pid=1` with marker and overlay write.
-   `--usb --rootfs` Wi-Fi on metal 2026-08-23: nmtui Rescan then Activate
-   associated to flintstone; `ping www.google.com` succeeded. `nmcli
-   device wifi connect … password` still failed secrets-not-provided
-   (`brcmf join_pref -52`). Pixel USB tether enumerates as `enu1`/`cdc_ncm`.
+   `--usb --rootfs` on metal 2026-08-23: `gum` 0.17.0, `fnmode=1`, nmtui
+   Rescan (first scan may time out), then `nmcli device wifi connect`
+   associated and `ping www.google.com` succeeded (`brcmf join_pref -52`
+   is noise). Pixel USB tether enumerates as `enu1`/`cdc_ncm`.
 2. `./bin/omarchy-mac-iso-make --usb` produces a GPT ESP + payload image on
    this Mac and boots; `test/unit` green; `bash -n` over every script.
    Container still open.

--- a/test/unit
+++ b/test/unit
@@ -60,6 +60,10 @@ check "rootfs pacstraps networkmanager and iwd" grep -q networkmanager \
   "${repo_root}/builder/build-rootfs.sh"
 check "NM live conf disables polkit auth" grep -q 'auth-polkit=false' \
   "${repo_root}/configs/usb/rootfs/nm-live.conf"
+check "rootfs pacstraps mesa and gum" grep -q ' mesa ' \
+  "${repo_root}/builder/build-rootfs.sh"
+check "hid_apple fnmode=1 is in the tree" grep -q 'fnmode=1' \
+  "${repo_root}/configs/usb/modprobe.d/hid_apple.conf"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 


### PR DESCRIPTION
## Summary

Puts Asahi mesa, asahi-audio, speakersafetyd, pipewire-pulse, and gum on the `--usb --rootfs` payload, plus `hid_apple fnmode=1` and `appledrm show_notch=1` (initramfs modprobe + systemd oneshot). Still not the Omarchy desktop. `asahi-scripts` stays out.

Proven on an M2 Max: `gum version 0.17.0`, `fnmode=1`, nmtui Rescan (first scan may time out), then `nmcli device wifi connect` and `ping www.google.com`.