### PR TITLE
Add omarchy-mac-install: clone live USB onto another stick

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1
 (proven on an M2 Max, 2026-08-23). `--rootfs` includes kernel modules, NetworkManager, `iwd`, Asahi mesa,
 asahi-audio, speakersafetyd, gum, `hid_apple fnmode=1`, and
 `appledrm show_notch=1`. Vendor firmware is copied from the internal ESP
-at boot. Still not the Omarchy desktop. Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
+at boot. Still not the Omarchy desktop. On the live USB, `omarchy-mac-install`
+clones this disk onto another USB (refuses NVMe and APFS). First cut is
+whole-disk `dd`, not LUKS or Omarchy. Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
 `nmcli device wifi connect 'SSID' password 'PSK'` (nmcli failed before a
 scan, succeeded after). `gum --version` and `fnmode=1` proven on metal.
 Default `--usb` without `--rootfs` still hangs at busybox pid 1.

--- a/README.md
+++ b/README.md
@@ -90,12 +90,17 @@ Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1
 (proven on an M2 Max, 2026-08-23). `--rootfs` includes kernel modules, NetworkManager, `iwd`, Asahi mesa,
 asahi-audio, speakersafetyd, gum, `hid_apple fnmode=1`, and
 `appledrm show_notch=1`. Vendor firmware is copied from the internal ESP
-at boot. Still not the Omarchy desktop. On the live USB, `omarchy-mac-install`
-clones this disk onto another USB (refuses NVMe and APFS). First cut is
-whole-disk `dd`, not LUKS or Omarchy. Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
+at boot. Still not the Omarchy desktop. `omarchy-mac-install` is on the live image
+and clones this disk onto another USB (refuses NVMe and APFS). First cut
+is a `dd` through the last partition (a 16GB-class stick is often a few
+hundred megabytes smaller than the live USB), not LUKS or Omarchy. It
+unmounts source and target first — cloning a mounted payload produced a
+btrfs-csum-corrupt copy that GRUB-booted then reset into NVMe. Proven from
+the installed Omarchy (2026-08-23), not from a booted live USB: 14.9G Lexar
+→ 14.5G stick, then that stick booted to autologin root, `gum version 2.0.0`,
+`fnmode=1`. Running the installer *on* the live USB is still untested. Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
 `nmcli device wifi connect 'SSID' password 'PSK'` (nmcli failed before a
-scan, succeeded after). `gum --version` and `fnmode=1` proven on metal.
-Default `--usb` without `--rootfs` still hangs at busybox pid 1.
+scan, succeeded after). Default `--usb` without `--rootfs` still hangs at busybox pid 1.
 
 Flash (destroys the target stick):
 

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -61,7 +61,8 @@ mount -t tmpfs tmpfs "$mnt/boot"
 
 log "pacstrap base networkmanager iwd mesa asahi-audio gum"
 pacstrap -c "$mnt" base networkmanager iwd mesa asahi-audio \
-  alsa-ucm-conf-asahi speakersafetyd pipewire-pulse gum
+  alsa-ucm-conf-asahi speakersafetyd pipewire-pulse gum \
+  parted gptfdisk btrfs-progs
 
 umount "$mnt/boot"
 umount "$mnt/run"
@@ -74,6 +75,9 @@ cp -a "/usr/lib/modules/$kver" "$mnt/usr/lib/modules/"
 
 install -m644 "$repo_root/configs/usb/rootfs/issue" "$mnt/etc/issue"
 install -d "$mnt/etc/systemd/system"
+install -d "$mnt/usr/local/sbin"
+install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-install" \
+  "$mnt/usr/local/sbin/omarchy-mac-install"
 install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-usb-ready.service" \
   "$mnt/etc/systemd/system/omarchy-mac-usb-ready.service"
 install -d "$mnt/etc/systemd/system/getty@tty1.service.d"

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -4,5 +4,6 @@ Wi-Fi: nmtui Rescan until SSIDs appear, then
 USB:   nmcli device connect enu1
 Check: cat /sys/module/hid_apple/parameters/fnmode   (want 1)
        gum --version
+Install (WIP, wipes the target disk): omarchy-mac-install
 
 

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -1,13 +1,15 @@
 #!/bin/bash
 # Clone this live USB onto another disk. Refuses NVMe, APFS, iBoot, Recovery,
-# and the live medium itself. First cut: whole-disk dd. Not an Omarchy install.
+# and the live medium itself. Copies through the last partition (not the whole
+# source disk — a 16GB-class stick is often smaller than the live USB). Not
+# an Omarchy install.
 set -euo pipefail
 
 APPLE_APFS=7c3457ef-0000-11aa-aa11-00306543ecac
 APPLE_IBOOT=69646961-6700-11aa-aa11-00306543ecac
 APPLE_RECOVERY=52637672-7900-11aa-aa11-00306543ecac
-# 4GiB: 512MiB ESP + 3GiB payload plus slack
-MIN_BYTES=$((4 * 1024 * 1024 * 1024))
+# GPT backup header + entries after the last partition
+GPT_BACKUP_BYTES=$((34 * 512))
 
 fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
 
@@ -24,6 +26,19 @@ live_disk=$(lsblk -no PKNAME "$live_partition")
 [[ -n $live_disk ]] || fail "could not find the disk that holds OMARCHYLIVE"
 source_dev=/dev/$live_disk
 
+# Bytes covering every partition on $1, plus slack for a backup GPT.
+# lsblk -b SIZE is bytes; START is 512-byte sectors.
+copy_bytes_for_disk() {
+  local disk=$1 name start size end=0
+  while read -r name start size; do
+    [[ $name == "$disk" ]] && continue
+    [[ -z $start || -z $size ]] && continue
+    (( start * 512 + size > end )) && end=$(( start * 512 + size ))
+  done < <(lsblk -lnb -o NAME,START,SIZE "/dev/$disk")
+  (( end > 0 )) || fail "no partitions on /dev/$disk"
+  printf '%s\n' $(( end + GPT_BACKUP_BYTES ))
+}
+
 disk_has_apple_partitions() {
   local disk=$1 type
   while read -r type; do
@@ -34,6 +49,16 @@ disk_has_apple_partitions() {
   return 1
 }
 
+unmount_disk() {
+  local dev=$1 mountpoint
+  while read -r mountpoint; do
+    [[ -z $mountpoint ]] && continue
+    umount "$mountpoint" || fail "could not unmount $mountpoint on $dev"
+  done < <(lsblk -ln -o MOUNTPOINT "$dev")
+}
+
+copy_bytes=$(copy_bytes_for_disk "$live_disk")
+
 candidates=()
 while read -r name size model tran; do
   [[ -z $name ]] && continue
@@ -41,12 +66,12 @@ while read -r name size model tran; do
   [[ $name == "$live_disk" ]] && continue
   [[ ${tran:-} == nvme ]] && continue
   disk_has_apple_partitions "$name" && continue
-  bytes=$(lsblk -bn -o SIZE "/dev/$name")
-  (( bytes >= MIN_BYTES )) || continue
+  bytes=$(lsblk -dn -b -o SIZE "/dev/$name")
+  (( bytes >= copy_bytes )) || continue
   candidates+=("$name  $size  ${model:-disk}  ${tran:-}")
 done < <(lsblk -dn -o NAME,SIZE,MODEL,TRAN)
 
-(( ${#candidates[@]} > 0 )) || fail "no eligible disks (need >=4GiB USB/SCSI, not NVMe, not the live USB)"
+(( ${#candidates[@]} > 0 )) || fail "no eligible disks (need USB/SCSI >= ${copy_bytes} bytes, not NVMe, not the live USB)"
 
 choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Destroy ALL data on which disk?")
 [[ -n $choice ]] || fail "cancelled"
@@ -56,19 +81,21 @@ target_dev=/dev/$target_name
 [[ $target_name == nvme* ]] && fail "refusing NVMe"
 [[ $target_name == "$live_disk" ]] && fail "refusing the live USB"
 disk_has_apple_partitions "$target_name" && fail "refusing a disk with APFS/iBoot/Recovery"
+target_bytes=$(lsblk -dn -b -o SIZE "$target_dev")
+(( target_bytes >= copy_bytes )) || fail "$target_dev is too small (need $copy_bytes bytes)"
 
 gum confirm \
-  "This will DESTROY every partition on $target_dev (${choice#*  }). The live USB $source_dev is copied onto it. Continue?" \
+  "This will DESTROY every partition on $target_dev (${choice#*  }). $copy_bytes bytes from $source_dev are copied onto it. Continue?" \
   || fail "cancelled"
 
-while read -r mountpoint; do
-  [[ -z $mountpoint ]] && continue
-  umount "$mountpoint" || true
-done < <(lsblk -ln -o MOUNTPOINT "$target_dev")
+unmount_disk "$target_dev"
+unmount_disk "$source_dev"
 sync
 
-printf '==> dd %s -> %s (whole disk clone)\n' "$source_dev" "$target_dev"
-dd if="$source_dev" of="$target_dev" bs=4M status=progress conv=fsync oflag=sync
+printf '==> dd %s -> %s (%s bytes, through last partition)\n' \
+  "$source_dev" "$target_dev" "$copy_bytes"
+dd if="$source_dev" of="$target_dev" bs=4M iflag=count_bytes count="$copy_bytes" \
+  status=progress conv=fsync oflag=sync
 sync
 partprobe "$target_dev" 2>/dev/null || true
 

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Clone this live USB onto another disk. Refuses NVMe, APFS, iBoot, Recovery,
+# and the live medium itself. First cut: whole-disk dd. Not an Omarchy install.
+set -euo pipefail
+
+APPLE_APFS=7c3457ef-0000-11aa-aa11-00306543ecac
+APPLE_IBOOT=69646961-6700-11aa-aa11-00306543ecac
+APPLE_RECOVERY=52637672-7900-11aa-aa11-00306543ecac
+# 4GiB: 512MiB ESP + 3GiB payload plus slack
+MIN_BYTES=$((4 * 1024 * 1024 * 1024))
+
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+[[ $EUID == 0 ]] || fail "run as root"
+command -v gum >/dev/null || fail "gum not found"
+command -v dd >/dev/null || fail "dd not found"
+
+live_partition=""
+if [[ -e /dev/disk/by-label/OMARCHYLIVE ]]; then
+  live_partition=$(readlink -f /dev/disk/by-label/OMARCHYLIVE)
+fi
+[[ -n $live_partition ]] || fail "no OMARCHYLIVE volume — plug in the live USB"
+live_disk=$(lsblk -no PKNAME "$live_partition")
+[[ -n $live_disk ]] || fail "could not find the disk that holds OMARCHYLIVE"
+source_dev=/dev/$live_disk
+
+disk_has_apple_partitions() {
+  local disk=$1 type
+  while read -r type; do
+    [[ -z $type ]] && continue
+    type=${type,,}
+    [[ $type == "$APPLE_APFS" || $type == "$APPLE_IBOOT" || $type == "$APPLE_RECOVERY" ]] && return 0
+  done < <(lsblk -n -o PARTTYPE "/dev/$disk")
+  return 1
+}
+
+candidates=()
+while read -r name size model tran; do
+  [[ -z $name ]] && continue
+  [[ $name == nvme* ]] && continue
+  [[ $name == "$live_disk" ]] && continue
+  [[ ${tran:-} == nvme ]] && continue
+  disk_has_apple_partitions "$name" && continue
+  bytes=$(lsblk -bn -o SIZE "/dev/$name")
+  (( bytes >= MIN_BYTES )) || continue
+  candidates+=("$name  $size  ${model:-disk}  ${tran:-}")
+done < <(lsblk -dn -o NAME,SIZE,MODEL,TRAN)
+
+(( ${#candidates[@]} > 0 )) || fail "no eligible disks (need >=4GiB USB/SCSI, not NVMe, not the live USB)"
+
+choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Destroy ALL data on which disk?")
+[[ -n $choice ]] || fail "cancelled"
+target_name=${choice%% *}
+target_dev=/dev/$target_name
+
+[[ $target_name == nvme* ]] && fail "refusing NVMe"
+[[ $target_name == "$live_disk" ]] && fail "refusing the live USB"
+disk_has_apple_partitions "$target_name" && fail "refusing a disk with APFS/iBoot/Recovery"
+
+gum confirm \
+  "This will DESTROY every partition on $target_dev (${choice#*  }). The live USB $source_dev is copied onto it. Continue?" \
+  || fail "cancelled"
+
+while read -r mountpoint; do
+  [[ -z $mountpoint ]] && continue
+  umount "$mountpoint" || true
+done < <(lsblk -ln -o MOUNTPOINT "$target_dev")
+sync
+
+printf '==> dd %s -> %s (whole disk clone)\n' "$source_dev" "$target_dev"
+dd if="$source_dev" of="$target_dev" bs=4M status=progress conv=fsync oflag=sync
+sync
+partprobe "$target_dev" 2>/dev/null || true
+
+if command -v sgdisk >/dev/null; then
+  sgdisk -e "$target_dev" || true
+fi
+
+printf '==> done. Unplug the live USB, cold-start, and boot the target the same way as the Lexar.\n'
+lsblk -o NAME,SIZE,FSTYPE,LABEL "$target_dev"

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -45,8 +45,12 @@ Spikes live in `~/code/omarchy-mac-iso-spike/`. Reports:
 | Os-package zip, from source | Raw zip: `esp/` tree + `root.img` (size multiple of 4 KiB). Optional `boot.img`, `icon`. `fdcopy` onto `/dev/rdiskNsM`. No sparse format. `INSTALLER_DATA` / `REPO_BASE` is the supported third-party hook. `supported_fw` filters IPSW versions (`12.3`, `12.3.1`, `13.5`, `14.8.3`), not kernel features. |
 | Alarm size precedent is **Minimal**, not a desktop | Alarm Minimal `root.img` is 2,209,614,225 bytes; Desktop is 12.7 GB in a **1.88 GiB** zip. This machine's `@` subvolume is ~13 GB (`du -sx /` does not cross `@home`). A full Omarchy image will look like Desktop, not Minimal. GitHub Releases' 2 GiB per-file cap is tight. |
 
-Not yet proven on the stick: an install `dd` onto a target disk. Overlay +
-`switch_root`, systemd userspace, and Wi-Fi association are done (2026-08-23).
+USB-to-USB `dd` (through last partition, not whole disk) is proven from
+the installed Omarchy (2026-08-23): 14.9G Lexar → 14.5G stick, then that
+stick booted to autologin root, `gum 2.0.0`, `fnmode=1`. We have not run
+`omarchy-mac-install` from a booted live USB. Overlay + `switch_root`,
+systemd userspace, and Wi-Fi association are done (2026-08-23). Not yet:
+LUKS, Omarchy packages, or install onto internal NVMe.
 
 ## Architecture: one rootfs, two front doors
 

--- a/test/unit
+++ b/test/unit
@@ -64,6 +64,10 @@ check "rootfs pacstraps mesa and gum" grep -q ' mesa ' \
   "${repo_root}/builder/build-rootfs.sh"
 check "hid_apple fnmode=1 is in the tree" grep -q 'fnmode=1' \
   "${repo_root}/configs/usb/modprobe.d/hid_apple.conf"
+check "install script refuses Apple partition GUIDs" grep -q 7c3457ef \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "sh -n omarchy-mac-install" bash -n \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 

--- a/test/unit
+++ b/test/unit
@@ -66,6 +66,10 @@ check "hid_apple fnmode=1 is in the tree" grep -q 'fnmode=1' \
   "${repo_root}/configs/usb/modprobe.d/hid_apple.conf"
 check "install script refuses Apple partition GUIDs" grep -q 7c3457ef \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install script copies through last partition not whole disk" grep -q iflag=count_bytes \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install script unmounts the live USB before dd" grep -q 'unmount_disk "$source_dev"' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "sh -n omarchy-mac-install" bash -n \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \


### PR DESCRIPTION
## Summary

Adds `omarchy-mac-install`, a gum TUI that clones the live USB onto another disk (refuses NVMe and Apple partition GUIDs). First cut is a `dd` through the last partition so a slightly smaller 16GB-class stick still fits, not LUKS or Omarchy. Unmounts source and target first — a mounted payload cloned into a corrupt btrfs.

Proven from the installed Omarchy on an M2 Max: 14.9G Lexar → 14.5G stick, then that stick booted to autologin root, `gum version 2.0.0`, `fnmode=1`. Not yet run from a booted live USB (the script would try to unmount its overlay lowerdir).