### PR TITLE
Run omarchy-mac-install from the live USB without unmounting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,13 @@ and clones this disk onto another USB (refuses NVMe and APFS). First cut
 is a `dd` through the last partition (a 16GB-class stick is often a few
 hundred megabytes smaller than the live USB), not LUKS or Omarchy. It
 unmounts source and target first — cloning a mounted payload produced a
-btrfs-csum-corrupt copy that GRUB-booted then reset into NVMe. Proven from
-the installed Omarchy (2026-08-23), not from a booted live USB: 14.9G Lexar
-→ 14.5G stick, then that stick booted to autologin root, `gum version 2.0.0`,
-`fnmode=1`. Running the installer *on* the live USB is still untested. Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
+btrfs-csum-corrupt copy that GRUB-booted then reset into NVMe. If this *is*
+the running live USB, the overlay lowerdir stays mounted and source is the
+overlay device (not `/dev/disk/by-label/OMARCHYLIVE`, which is wrong when a
+clone is plugged in). The clone gets a new btrfs UUID. Proven from the
+installed Omarchy (2026-08-23): 14.9G Lexar → 14.5G stick, then that stick
+booted to autologin root, `gum version 2.0.0`, `fnmode=1`. Running the
+installer *on* the live USB is still untested. Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
 `nmcli device wifi connect 'SSID' password 'PSK'` (nmcli failed before a
 scan, succeeded after). Default `--usb` without `--rootfs` still hangs at busybox pid 1.
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,13 @@ unmounts source and target first — cloning a mounted payload produced a
 btrfs-csum-corrupt copy that GRUB-booted then reset into NVMe. If this *is*
 the running live USB, the overlay lowerdir stays mounted and source is the
 overlay device (not `/dev/disk/by-label/OMARCHYLIVE`, which is wrong when a
-clone is plugged in). The clone gets a new btrfs UUID. Proven from the
-installed Omarchy (2026-08-23): 14.9G Lexar → 14.5G stick, then that stick
-booted to autologin root, `gum version 2.0.0`, `fnmode=1`. Running the
-installer *on* the live USB is still untested. Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
+clone is plugged in). The clone gets a new btrfs UUID (after udev sees the payload; a first
+from-live run skipped `btrfstune` when `lsblk` still had empty FSTYPE).
+Proven from the installed Omarchy (2026-08-23): 14.9G Lexar → 14.5G stick,
+then that stick booted to autologin root, `gum version 2.0.0`, `fnmode=1`.
+Proven *on* the live USB (2026-08-23): 14.5G stick → Lexar, then that Lexar
+booted after `usb reset` twice (`05dc:c753` skipped until the bus came up).
+Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
 `nmcli device wifi connect 'SSID' password 'PSK'` (nmcli failed before a
 scan, succeeded after). Default `--usb` without `--rootfs` still hangs at busybox pid 1.
 
@@ -113,10 +116,14 @@ sudo dd if=release/omarchy-mac-iso-usb/omarchy-mac-usb.img of=/dev/sdX bs=4M sta
 
 **Shutdown, then power on** — a warm reboot often leaves Type-C/PD
 unenumerated in U-Boot (`0 Storage Device(s) found`). After a cold start,
-interrupt U-Boot (~1s) if NVMe already has Linux, and load the stick's
-GRUB explicitly (do not `saveenv`):
+interrupt U-Boot (~1s) if NVMe already has Linux. If `usb storage` is empty
+or U-Boot skips the stick (`Cannot read configuration, skipping device
+05dc:c753` on the Lexar), `usb reset` until storage appears (twice on
+metal, 2026-08-23), then load the stick's GRUB explicitly (do not `saveenv`):
 
 ```
+usb reset
+usb storage
 load usb 0:1 ${kernel_addr_r} /EFI/BOOT/BOOTAA64.EFI
 bootefi ${kernel_addr_r} ${fdtcontroladdr}
 ```

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Clone this live USB onto another disk. Refuses NVMe, APFS, iBoot, Recovery,
 # and the live medium itself. Copies through the last partition (not the whole
-# source disk — a 16GB-class stick is often smaller than the live USB). Not
-# an Omarchy install.
+# source disk — a 16GB-class stick is often smaller than the live USB). When
+# this is the running live USB, keep the overlay lowerdir mounted. Not an
+# Omarchy install.
 set -euo pipefail
 
 APPLE_APFS=7c3457ef-0000-11aa-aa11-00306543ecac
@@ -17,14 +18,31 @@ fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
 command -v gum >/dev/null || fail "gum not found"
 command -v dd >/dev/null || fail "dd not found"
 
+# Prefer the overlay lowerdir when we *are* the live USB. Two OMARCHYLIVE
+# labels (source + a previous clone) make by-label point at the wrong disk.
+overlay_payload_device() {
+  local src
+  [[ -e /omarchy-mac-overlay-write ]] || return 1
+  src=$(findmnt -nro SOURCE /run/omarchy-root 2>/dev/null || true)
+  src=${src%%[[]*}
+  [[ -b $src ]] || return 1
+  printf '%s\n' "$src"
+}
+
 live_partition=""
-if [[ -e /dev/disk/by-label/OMARCHYLIVE ]]; then
+if live_partition=$(overlay_payload_device); then
+  :
+elif [[ -e /dev/disk/by-label/OMARCHYLIVE ]]; then
   live_partition=$(readlink -f /dev/disk/by-label/OMARCHYLIVE)
 fi
 [[ -n $live_partition ]] || fail "no OMARCHYLIVE volume — plug in the live USB"
 live_disk=$(lsblk -no PKNAME "$live_partition")
 [[ -n $live_disk ]] || fail "could not find the disk that holds OMARCHYLIVE"
 source_dev=/dev/$live_disk
+running_from_this_live_usb=0
+if overlay=$(overlay_payload_device); then
+  [[ $overlay == "$live_partition" ]] && running_from_this_live_usb=1
+fi
 
 # Bytes covering every partition on $1, plus slack for a backup GPT.
 # lsblk -b SIZE is bytes; START is 512-byte sectors.
@@ -50,11 +68,26 @@ disk_has_apple_partitions() {
 }
 
 unmount_disk() {
-  local dev=$1 mountpoint
+  local dev=$1 mountpoint skip_live_root=${2:-0}
   while read -r mountpoint; do
     [[ -z $mountpoint ]] && continue
+    if (( skip_live_root == 1 )); then
+      [[ $mountpoint == /run/omarchy-root ]] && continue
+      [[ $mountpoint == / ]] && continue
+    fi
     umount "$mountpoint" || fail "could not unmount $mountpoint on $dev"
   done < <(lsblk -ln -o MOUNTPOINT "$dev")
+}
+
+payload_partition_on() {
+  local disk=$1 name fstype
+  while read -r name fstype; do
+    [[ $name == "$disk" ]] && continue
+    [[ $fstype == btrfs ]] || continue
+    printf '/dev/%s\n' "$name"
+    return 0
+  done < <(lsblk -ln -o NAME,FSTYPE "/dev/$disk")
+  return 1
 }
 
 copy_bytes=$(copy_bytes_for_disk "$live_disk")
@@ -89,7 +122,11 @@ gum confirm \
   || fail "cancelled"
 
 unmount_disk "$target_dev"
-unmount_disk "$source_dev"
+if (( running_from_this_live_usb == 1 )); then
+  unmount_disk "$source_dev" 1
+else
+  unmount_disk "$source_dev"
+fi
 sync
 
 printf '==> dd %s -> %s (%s bytes, through last partition)\n' \
@@ -98,10 +135,20 @@ dd if="$source_dev" of="$target_dev" bs=4M iflag=count_bytes count="$copy_bytes"
   status=progress conv=fsync oflag=sync
 sync
 partprobe "$target_dev" 2>/dev/null || true
+command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
 
 if command -v sgdisk >/dev/null; then
   sgdisk -e "$target_dev" || true
 fi
 
+target_payload=$(payload_partition_on "$target_name" || true)
+if [[ -n $target_payload ]] && command -v btrfstune >/dev/null; then
+  printf '==> new btrfs UUID on %s (clone must not share the live fsid)\n' "$target_payload"
+  if command -v btrfs >/dev/null; then
+    btrfs device scan --forget "$target_payload" || true
+  fi
+  btrfstune -f -u "$target_payload"
+fi
+
 printf '==> done. Unplug the live USB, cold-start, and boot the target the same way as the Lexar.\n'
-lsblk -o NAME,SIZE,FSTYPE,LABEL "$target_dev"
+lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -135,20 +135,31 @@ dd if="$source_dev" of="$target_dev" bs=4M iflag=count_bytes count="$copy_bytes"
   status=progress conv=fsync oflag=sync
 sync
 partprobe "$target_dev" 2>/dev/null || true
-command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
-
 if command -v sgdisk >/dev/null; then
   sgdisk -e "$target_dev" || true
 fi
+partprobe "$target_dev" 2>/dev/null || true
+command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
 
-target_payload=$(payload_partition_on "$target_name" || true)
+target_payload=""
+for _ in 1 2 3 4 5 6; do
+  target_payload=$(payload_partition_on "$target_name" || true)
+  [[ -n $target_payload ]] && break
+  sleep 1
+  partprobe "$target_dev" 2>/dev/null || true
+done
 if [[ -n $target_payload ]] && command -v btrfstune >/dev/null; then
   printf '==> new btrfs UUID on %s (clone must not share the live fsid)\n' "$target_payload"
   if command -v btrfs >/dev/null; then
     btrfs device scan --forget "$target_payload" || true
   fi
   btrfstune -f -u "$target_payload"
+else
+  printf 'warning: no btrfs partition on %s yet; clone UUID was not rewritten\n' \
+    "$target_dev" >&2
 fi
 
-printf '==> done. Unplug the live USB, cold-start, and boot the target the same way as the Lexar.\n'
+printf '==> done. Unplug the live USB %s, cold-start, boot the target %s.\n' \
+  "$source_dev" "$target_dev"
+printf '    U-Boot: usb reset until usb storage lists that stick, then load usb 0:1 ...\n'
 lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -47,10 +47,11 @@ Spikes live in `~/code/omarchy-mac-iso-spike/`. Reports:
 
 USB-to-USB `dd` (through last partition, not whole disk) is proven from
 the installed Omarchy (2026-08-23): 14.9G Lexar → 14.5G stick, then that
-stick booted to autologin root, `gum 2.0.0`, `fnmode=1`. We have not run
-`omarchy-mac-install` from a booted live USB. Overlay + `switch_root`,
-systemd userspace, and Wi-Fi association are done (2026-08-23). Not yet:
-LUKS, Omarchy packages, or install onto internal NVMe.
+stick booted to autologin root, `gum 2.0.0`, `fnmode=1`. Proven from a
+booted live USB the same day: 14.5G stick → Lexar; U-Boot skipped
+`05dc:c753` until `usb reset` twice, then the Lexar booted. Overlay +
+`switch_root`, systemd userspace, and Wi-Fi association are done
+(2026-08-23). Not yet: LUKS, Omarchy packages, or install onto internal NVMe.
 
 ## Architecture: one rootfs, two front doors
 

--- a/test/unit
+++ b/test/unit
@@ -70,6 +70,10 @@ check "install script copies through last partition not whole disk" grep -q ifla
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install script unmounts the live USB before dd" grep -q 'unmount_disk "$source_dev"' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install script keeps overlay lowerdir mounted" grep -q omarchy-mac-overlay-write \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install script rewrites clone btrfs UUID" grep -q 'btrfstune -f -u' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "sh -n omarchy-mac-install" bash -n \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \


### PR DESCRIPTION
## Summary

`omarchy-mac-install` can run on the live USB: it leaves the overlay lowerdir mounted, takes source from that device (not `by-label`, which is wrong with two `OMARCHYLIVE` volumes), and rewrites the clone's btrfs UUID after udev actually sees the payload.

Proven on an M2 Max: 14.5G stick → Lexar, then the Lexar booted after `usb reset` twice (U-Boot skipped `05dc:c753` until the bus came up).