### PR TITLE
Install a persistent USB root (no overlay, no LUKS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,13 @@ load usb 0:1 ${kernel_addr_r} /EFI/BOOT/BOOTAA64.EFI
 bootefi ${kernel_addr_r} ${fdtcontroladdr}
 ```
 
-`bootflow select` of the USB row can still load NVMe's
-`/EFI/BOOT/BOOTAA64.EFI`. `bootcmd_usb0` is not defined. USB GRUB prints
-`OMARCHY USB GRUB (not the NVMe ESP)`. Omarchy Linux / Advanced options
-means you are on NVMe.
+`bootflow select` of a USB *row* can still load NVMe's
+`/EFI/BOOT/BOOTAA64.EFI` (same path). `bootflow scan -l` then select the
+`usb_mass_storage` entry (seq 2 on metal, 2026-08-24) and `bootflow boot`
+does load the stick. `load usb 0:1 …` / `bootefi` still works. `bootcmd_usb0`
+is not defined. Live GRUB prints `OMARCHY USB GRUB`; installed GRUB prints
+`OMARCHY USB INSTALL` / menu `Omarchy Mac (USB root)`. Omarchy Linux /
+Advanced options means you are on NVMe.
 
 Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
 `nmcli device wifi connect 'SSID' password 'PSK'`.
@@ -134,7 +137,8 @@ GUIDs):
   `gum 2.0.0`, `fnmode=1`.
 - **Install** — GPT ESP (`OMARCHYBOOT`) + btrfs root (`OMARCHYROOT`) filling
   the disk, copy the payload, `btrfs resize max`, GRUB with `root=UUID=`.
-  Persistent root, no overlay, no LUKS, not Omarchy packages. USB GRUB
-  searches for `/omarchy-usb-live` or `/omarchy-usb-install` so it cannot
-  load the NVMe ESP's `/grub/grub.cfg`. Rebuild `--usb --rootfs` so the
-  live image has grub and dosfstools.
+  Persistent root, no overlay, no LUKS, not Omarchy packages. Do not name
+  the initrd `initramfs-linux-asahi.img` (NVMe ESP has that; GRUB then
+  loads the LUKS initramfs). Proven on an M2 Max (2026-08-24): 14.5G stick,
+  `omarchy-usb-wait` mounted `UUID=e68e2508-…`, systemd mounted
+  `OMARCHYBOOT`/`OMARCHYROOT`, autologin `root@omarchy-mac`.

--- a/README.md
+++ b/README.md
@@ -134,5 +134,7 @@ GUIDs):
   `gum 2.0.0`, `fnmode=1`.
 - **Install** — GPT ESP (`OMARCHYBOOT`) + btrfs root (`OMARCHYROOT`) filling
   the disk, copy the payload, `btrfs resize max`, GRUB with `root=UUID=`.
-  Persistent root, no overlay, no LUKS, not Omarchy packages. Untested on
-  metal. Rebuild `--usb --rootfs` so the live image has grub and dosfstools.
+  Persistent root, no overlay, no LUKS, not Omarchy packages. USB GRUB
+  searches for `/omarchy-usb-live` or `/omarchy-usb-install` so it cannot
+  load the NVMe ESP's `/grub/grub.cfg`. Rebuild `--usb --rootfs` so the
+  live image has grub and dosfstools.

--- a/README.md
+++ b/README.md
@@ -80,33 +80,17 @@ initramfs with `dwc3-apple`) and a btrfs payload labelled `OMARCHYLIVE`
 (subvol `@`, tiny busybox `/sbin/init`). No root required. Copying files
 onto an existing FAT stick is not enough — the payload is its own partition.
 
-S3 systemd userspace (not the Omarchy desktop) — needs root, `arch-install-scripts`:
+Systemd userspace (not the Omarchy desktop) — needs root, `arch-install-scripts`:
 
 ```
 sudo ./bin/omarchy-mac-iso-make --usb --rootfs
 ```
 
-Success prints `OMARCHY_MAC_USB_SYSTEMD` and an autologin root shell on tty1
-(proven on an M2 Max, 2026-08-23). `--rootfs` includes kernel modules, NetworkManager, `iwd`, Asahi mesa,
-asahi-audio, speakersafetyd, gum, `hid_apple fnmode=1`, and
-`appledrm show_notch=1`. Vendor firmware is copied from the internal ESP
-at boot. Still not the Omarchy desktop. `omarchy-mac-install` is on the live image
-and clones this disk onto another USB (refuses NVMe and APFS). First cut
-is a `dd` through the last partition (a 16GB-class stick is often a few
-hundred megabytes smaller than the live USB), not LUKS or Omarchy. It
-unmounts source and target first — cloning a mounted payload produced a
-btrfs-csum-corrupt copy that GRUB-booted then reset into NVMe. If this *is*
-the running live USB, the overlay lowerdir stays mounted and source is the
-overlay device (not `/dev/disk/by-label/OMARCHYLIVE`, which is wrong when a
-clone is plugged in). The clone gets a new btrfs UUID (after udev sees the payload; a first
-from-live run skipped `btrfstune` when `lsblk` still had empty FSTYPE).
-Proven from the installed Omarchy (2026-08-23): 14.9G Lexar → 14.5G stick,
-then that stick booted to autologin root, `gum version 2.0.0`, `fnmode=1`.
-Proven *on* the live USB (2026-08-23): 14.5G stick → Lexar, then that Lexar
-booted after `usb reset` twice (`05dc:c753` skipped until the bus came up).
-Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
-`nmcli device wifi connect 'SSID' password 'PSK'` (nmcli failed before a
-scan, succeeded after). Default `--usb` without `--rootfs` still hangs at busybox pid 1.
+Autologin root on tty1. Payload has NetworkManager, `iwd`, Asahi mesa,
+asahi-audio, gum, `hid_apple fnmode=1`, `appledrm show_notch=1`, parted,
+gptfdisk, btrfs-progs, dosfstools, and grub. Vendor firmware is copied from
+the internal ESP at boot. Default `--usb` without `--rootfs` still hangs at
+busybox pid 1.
 
 Flash (destroys the target stick):
 
@@ -114,12 +98,14 @@ Flash (destroys the target stick):
 sudo dd if=release/omarchy-mac-iso-usb/omarchy-mac-usb.img of=/dev/sdX bs=4M status=progress conv=fsync
 ```
 
+### U-Boot
+
 **Shutdown, then power on** — a warm reboot often leaves Type-C/PD
-unenumerated in U-Boot (`0 Storage Device(s) found`). After a cold start,
-interrupt U-Boot (~1s) if NVMe already has Linux. If `usb storage` is empty
-or U-Boot skips the stick (`Cannot read configuration, skipping device
-05dc:c753` on the Lexar), `usb reset` until storage appears (twice on
-metal, 2026-08-23), then load the stick's GRUB explicitly (do not `saveenv`):
+unenumerated (`0 Storage Device(s) found`). Interrupt U-Boot (~1s) if NVMe
+already has Linux. If `usb storage` is empty or U-Boot skips the stick
+(`Cannot read configuration, skipping device 05dc:c753` on the Lexar),
+`usb reset` until storage appears (twice on metal, 2026-08-23). Do not
+`saveenv`.
 
 ```
 usb reset
@@ -129,14 +115,24 @@ bootefi ${kernel_addr_r} ${fdtcontroladdr}
 ```
 
 `bootflow select` of the USB row can still load NVMe's
-`/EFI/BOOT/BOOTAA64.EFI` (same path on both ESPs). `bootcmd_usb0` is not
-defined on this U-Boot. A fresh UEFI-only Mac has no NVMe EFI payload, so
-the stick should win automatically after a cold start.
+`/EFI/BOOT/BOOTAA64.EFI`. `bootcmd_usb0` is not defined. USB GRUB prints
+`OMARCHY USB GRUB (not the NVMe ESP)`. Omarchy Linux / Advanced options
+means you are on NVMe.
 
-USB GRUB prints `OMARCHY USB GRUB (not the NVMe ESP)` and has one entry.
-Omarchy Linux / Advanced options means you are on NVMe.
+Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
+`nmcli device wifi connect 'SSID' password 'PSK'`.
 
-Busybox `--usb` prints `OMARCHY_MAC_USB_READY`, then
-`OMARCHY_MAC_USB_USERSPACE pid=1`, and hangs. `--usb --rootfs` prints
-`OMARCHY_MAC_USB_SYSTEMD` and drops to a root shell. Neither is a full
-Omarchy desktop or installer.
+### Clone vs install
+
+On the live USB, `omarchy-mac-install` (refuses NVMe and Apple partition
+GUIDs):
+
+- **Clone** — `dd` through the last partition onto another stick (a 16GB-class
+  stick is often smaller than the live USB). Unmounts source and target first
+  unless this *is* the running live overlay. Rewrites the clone btrfs UUID.
+  Proven from Omarchy and from the live USB (2026-08-23): Lexar ↔ 14.5G stick,
+  `gum 2.0.0`, `fnmode=1`.
+- **Install** — GPT ESP (`OMARCHYBOOT`) + btrfs root (`OMARCHYROOT`) filling
+  the disk, copy the payload, `btrfs resize max`, GRUB with `root=UUID=`.
+  Persistent root, no overlay, no LUKS, not Omarchy packages. Untested on
+  metal. Rebuild `--usb --rootfs` so the live image has grub and dosfstools.

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -84,6 +84,8 @@ install -m644 "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" \
   "$mnt/usr/local/share/omarchy-mac-iso/mkinitcpio-install.conf"
 install -m644 "$repo_root/configs/usb/grub-embed.cfg" \
   "$mnt/usr/local/share/omarchy-mac-iso/grub-embed.cfg"
+install -m644 "$repo_root/configs/usb/grub-embed-install.cfg" \
+  "$mnt/usr/local/share/omarchy-mac-iso/grub-embed-install.cfg"
 install -m644 "$repo_root/configs/usb-initcpio/hooks/omarchy-usb-wait" \
   "$mnt/usr/local/share/omarchy-mac-iso/initcpio/hooks/omarchy-usb-wait"
 install -m644 "$repo_root/configs/usb-initcpio/install/omarchy-usb-wait" \

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -62,7 +62,7 @@ mount -t tmpfs tmpfs "$mnt/boot"
 log "pacstrap base networkmanager iwd mesa asahi-audio gum"
 pacstrap -c "$mnt" base networkmanager iwd mesa asahi-audio \
   alsa-ucm-conf-asahi speakersafetyd pipewire-pulse gum \
-  parted gptfdisk btrfs-progs
+  parted gptfdisk btrfs-progs dosfstools grub
 
 umount "$mnt/boot"
 umount "$mnt/run"
@@ -78,6 +78,25 @@ install -d "$mnt/etc/systemd/system"
 install -d "$mnt/usr/local/sbin"
 install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-install" \
   "$mnt/usr/local/sbin/omarchy-mac-install"
+install -d "$mnt/usr/local/share/omarchy-mac-iso/initcpio/hooks"
+install -d "$mnt/usr/local/share/omarchy-mac-iso/initcpio/install"
+install -m644 "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" \
+  "$mnt/usr/local/share/omarchy-mac-iso/mkinitcpio-install.conf"
+install -m644 "$repo_root/configs/usb/grub-embed.cfg" \
+  "$mnt/usr/local/share/omarchy-mac-iso/grub-embed.cfg"
+install -m644 "$repo_root/configs/usb-initcpio/hooks/omarchy-usb-wait" \
+  "$mnt/usr/local/share/omarchy-mac-iso/initcpio/hooks/omarchy-usb-wait"
+install -m644 "$repo_root/configs/usb-initcpio/install/omarchy-usb-wait" \
+  "$mnt/usr/local/share/omarchy-mac-iso/initcpio/install/omarchy-usb-wait"
+# asahi-scripts is not pacstrapped (its alpm hooks mount the host ESP).
+# Copy only what mkinitcpio needs to build an installed-USB initramfs.
+[[ -f /usr/lib/initcpio/hooks/asahi ]] || fail "host asahi initcpio hook missing"
+install -m644 /usr/lib/initcpio/hooks/asahi \
+  "$mnt/usr/local/share/omarchy-mac-iso/initcpio/hooks/asahi"
+install -m644 /usr/lib/initcpio/install/asahi \
+  "$mnt/usr/local/share/omarchy-mac-iso/initcpio/install/asahi"
+mkdir -p "$mnt/usr/share"
+cp -a /usr/share/asahi-scripts "$mnt/usr/share/asahi-scripts"
 install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-usb-ready.service" \
   "$mnt/etc/systemd/system/omarchy-mac-usb-ready.service"
 install -d "$mnt/etc/systemd/system/getty@tty1.service.d"

--- a/builder/build-usb-image.sh
+++ b/builder/build-usb-image.sh
@@ -89,6 +89,7 @@ mkdir -p "$mnt/EFI/BOOT" "$mnt/grub"
 cp "$work/BOOTAA64.EFI" "$mnt/EFI/BOOT/BOOTAA64.EFI"
 cp "$repo_root/configs/usb/grub.cfg" "$mnt/EFI/BOOT/grub.cfg"
 cp "$repo_root/configs/usb/grub.cfg" "$mnt/grub/grub.cfg"
+: >"$mnt/omarchy-usb-live"
 cp /boot/vmlinuz-linux-asahi "$mnt/vmlinuz-linux-asahi"
 cp "$work/initramfs-omarchy-usb.img" "$mnt/initramfs-omarchy-usb.img"
 sync

--- a/builder/build-usb-image.sh
+++ b/builder/build-usb-image.sh
@@ -53,10 +53,10 @@ mkinitcpio -n \
 log "Building standalone GRUB"
 grub-mkstandalone -O arm64-efi \
   --fonts="" --locales="" --themes="" \
-  --install-modules="linux fat ext2 btrfs part_gpt search search_label search_fs_uuid echo normal configfile gzio reboot sleep" \
-  --modules="part_gpt fat search search_label linux echo normal" \
+  --install-modules="linux fat ext2 btrfs part_gpt search search_label search_fs_uuid search_fs_file echo normal configfile gzio reboot sleep" \
+  --modules="part_gpt fat search search_fs_file configfile linux echo normal" \
   -o "$work/BOOTAA64.EFI" \
-  "boot/grub/grub.cfg=$repo_root/configs/usb/grub.cfg"
+  "boot/grub/grub.cfg=$repo_root/configs/usb/grub-embed.cfg"
 
 # 512 MiB FAT ESP, then the btrfs payload, 1 MiB GPT head/tail.
 fat_mib=512

--- a/builder/build-usb-image.sh
+++ b/builder/build-usb-image.sh
@@ -50,6 +50,14 @@ mkinitcpio -n \
   -k "$kver" \
   -g "$work/initramfs-omarchy-usb.img"
 
+log "Building install initramfs (USB root, no overlay)"
+mkinitcpio -n \
+  -c "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" \
+  -D /usr/lib/initcpio \
+  -D "$repo_root/configs/usb-initcpio" \
+  -k "$kver" \
+  -g "$work/initramfs-linux-asahi.img"
+
 log "Building standalone GRUB"
 grub-mkstandalone -O arm64-efi \
   --fonts="" --locales="" --themes="" \
@@ -92,6 +100,7 @@ cp "$repo_root/configs/usb/grub.cfg" "$mnt/grub/grub.cfg"
 : >"$mnt/omarchy-usb-live"
 cp /boot/vmlinuz-linux-asahi "$mnt/vmlinuz-linux-asahi"
 cp "$work/initramfs-omarchy-usb.img" "$mnt/initramfs-omarchy-usb.img"
+cp "$work/initramfs-linux-asahi.img" "$mnt/initramfs-linux-asahi.img"
 sync
 
 udisksctl unmount -b "$loop_dev" --no-user-interaction >/dev/null
@@ -111,6 +120,7 @@ dd if="$work/payload.img" of="$disk" bs=1M seek="$esp_end_mib" conv=notrunc stat
 
 cp "$work/BOOTAA64.EFI" "$out_dir/BOOTAA64.EFI"
 cp "$work/initramfs-omarchy-usb.img" "$out_dir/initramfs-omarchy-usb.img"
+cp "$work/initramfs-linux-asahi.img" "$out_dir/initramfs-linux-asahi.img"
 cp "$work/payload.img" "$out_dir/payload.img"
 cp /boot/vmlinuz-linux-asahi "$out_dir/vmlinuz-linux-asahi"
 cp "$repo_root/configs/usb/grub.cfg" "$out_dir/grub.cfg"

--- a/configs/usb-initcpio/hooks/omarchy-usb-wait
+++ b/configs/usb-initcpio/hooks/omarchy-usb-wait
@@ -1,0 +1,51 @@
+#!/usr/bin/ash
+# SPDX-License-Identifier: MIT
+#
+# Root is on USB. dwc3-apple can take several seconds. Wait for the
+# UUID (or OMARCHYROOT) before the filesystems hook mounts it.
+
+hang() {
+  echo "==> $*" >/dev/console
+  echo "==> $*"
+  while true; do
+    sleep 3600
+  done
+}
+
+root_uuid_from_cmdline() {
+  local arg
+  for arg in $(cat /proc/cmdline); do
+    case "$arg" in
+      root=UUID=*)
+        echo "${arg#root=UUID=}"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+run_hook() {
+  if command -v udevadm >/dev/null 2>&1; then
+    udevadm settle --timeout=10 2>/dev/null
+    udevadm trigger --action=add 2>/dev/null
+    udevadm settle --timeout=10 2>/dev/null
+  fi
+  sleep 2
+
+  uuid=$(root_uuid_from_cmdline || true)
+  i=0
+  while [ "$i" -lt 30 ]; do
+    if [ -n "$uuid" ] && [ -e /dev/disk/by-uuid/"$uuid" ]; then
+      echo "==> omarchy-usb-wait: root UUID=$uuid" >/dev/console
+      return 0
+    fi
+    if [ -e /dev/disk/by-label/OMARCHYROOT ]; then
+      echo "==> omarchy-usb-wait: root label=OMARCHYROOT" >/dev/console
+      return 0
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  hang "omarchy-usb-wait: root device never appeared (USB not enumerated?)"
+}

--- a/configs/usb-initcpio/install/omarchy-usb-wait
+++ b/configs/usb-initcpio/install/omarchy-usb-wait
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+build() {
+  add_binary /usr/bin/udevadm
+  add_runscript
+}
+
+help() {
+  cat <<HELPEOF
+Wait for a USB root filesystem (UUID from the kernel cmdline, or label
+OMARCHYROOT) before the filesystems hook mounts it.
+HELPEOF
+}

--- a/configs/usb-initcpio/mkinitcpio-install.conf
+++ b/configs/usb-initcpio/mkinitcpio-install.conf
@@ -1,0 +1,28 @@
+# Initramfs for a persistent USB root (not the live overlay).
+# Same Type-C modules as the live image; no overlay/loop.
+
+MODULES=(
+  apple-tunable
+  phy_apple_atc
+  mux_apple_display_crossbar
+  typec
+  tps6598x_core
+  tps6598x
+  dwc3
+  dwc3_apple
+  xhci_plat_hcd
+  xhci_hcd
+  usb_storage
+  uas
+  btrfs
+  nls_iso8859_1
+)
+
+BINARIES=()
+
+FILES=()
+
+HOOKS=(base asahi udev omarchy-usb-wait filesystems)
+
+COMPRESSION="zstd"
+COMPRESSION_OPTIONS=(-T0 -3)

--- a/configs/usb/grub-embed-install.cfg
+++ b/configs/usb/grub-embed-install.cfg
@@ -1,0 +1,4 @@
+# Embedded in the installed USB BOOTAA64.EFI. Must not match the NVMe
+# ESP or the live USB (/grub/grub.cfg exists on both).
+search --no-floppy --file /omarchy-usb-install --set=root
+configfile /grub/grub.cfg

--- a/configs/usb/grub-embed.cfg
+++ b/configs/usb/grub-embed.cfg
@@ -1,4 +1,4 @@
-# Embedded in BOOTAA64.EFI. The real menu lives on the ESP so live vs
-# installed systems can ship different grub.cfg without rebuilding GRUB.
-search --no-floppy --file /grub/grub.cfg --set=root
+# Embedded in BOOTAA64.EFI. Search a file that exists only on the live
+# USB ESP — /grub/grub.cfg also lives on the NVMe Omarchy ESP.
+search --no-floppy --file /omarchy-usb-live --set=root
 configfile /grub/grub.cfg

--- a/configs/usb/grub-embed.cfg
+++ b/configs/usb/grub-embed.cfg
@@ -1,0 +1,4 @@
+# Embedded in BOOTAA64.EFI. The real menu lives on the ESP so live vs
+# installed systems can ship different grub.cfg without rebuilding GRUB.
+search --no-floppy --file /grub/grub.cfg --set=root
+configfile /grub/grub.cfg

--- a/configs/usb/grub.cfg
+++ b/configs/usb/grub.cfg
@@ -10,6 +10,6 @@ search --no-floppy --file /initramfs-omarchy-usb.img --set=root
 
 menuentry 'Omarchy Mac live (USB)' {
   echo 'GRUB is running from the USB ESP'
-  linux /vmlinuz-linux-asahi loglevel=7
+  linux /vmlinuz-linux-asahi loglevel=3
   initrd /initramfs-omarchy-usb.img
 }

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -5,5 +5,6 @@ USB:   nmcli device connect enu1
 Check: cat /sys/module/hid_apple/parameters/fnmode   (want 1)
        gum --version
 Install (WIP, wipes the target disk): omarchy-mac-install
+         gum: Install to a disk (persistent root) or Clone this live USB
 
 

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -17,6 +17,10 @@ fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
 command -v gum >/dev/null || fail "gum not found"
 command -v dd >/dev/null || fail "dd not found"
 
+# tty1 is also the kmsg console (live GRUB uses loglevel=7). printk
+# overwrites gum; drop console loglevel for the TUI.
+dmesg -n 1 2>/dev/null || true
+
 # Prefer the overlay lowerdir when we *are* the live USB. Two OMARCHYLIVE
 # labels (source + a previous clone) make by-label point at the wrong disk.
 overlay_payload_device() {
@@ -142,6 +146,7 @@ pick_target_disk() {
   [[ $target_name == nvme* ]] && fail "refusing NVMe"
   [[ $target_name == "$live_disk" ]] && fail "refusing the live USB"
   disk_has_apple_partitions "$target_name" && fail "refusing a disk with APFS/iBoot/Recovery"
+  printf '==> selected %s\n' "$target_dev"
 }
 
 clone_live_usb() {
@@ -204,9 +209,11 @@ install_persistent_root() {
   payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
   min_bytes=$(( ESP_MIB * 1024 * 1024 + payload_bytes + 64 * 1024 * 1024 ))
   pick_target_disk "$min_bytes"
+  printf '==> confirm DESTROY of %s (arrow keys, then enter)\n' "$target_dev"
   gum confirm \
-    "This will DESTROY $target_dev (${choice#*  }) and install a persistent USB root (no overlay, no LUKS). Continue?" \
+    "DESTROY $target_dev (${choice#*  }) and install a persistent USB root (no overlay, no LUKS)?" \
     || fail "cancelled"
+  printf '==> confirmed\n'
 
   source_esp=$(esp_partition_on "$live_disk" || true)
   [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
@@ -294,7 +301,7 @@ set default=0
 search --no-floppy --file /initramfs-linux-asahi.img --set=root
 
 menuentry 'Omarchy Mac (USB root)' {
-  linux /vmlinuz-linux-asahi root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=7
+  linux /vmlinuz-linux-asahi root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
   initrd /initramfs-linux-asahi.img
 }
 EOF

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -192,15 +192,13 @@ clone_live_usb() {
 
 install_persistent_root() {
   local payload_bytes min_bytes source_esp esp_part root_part
-  local root_mnt esp_mnt live_esp_mnt kernel
+  local root_mnt esp_mnt live_esp_mnt
   local root_uuid esp_uuid grub_cfg work
 
   command -v parted >/dev/null || fail "parted not found"
   command -v mkfs.vfat >/dev/null || fail "mkfs.vfat not found — rebuild with --usb --rootfs (dosfstools)"
   command -v mkfs.btrfs >/dev/null || fail "btrfs-progs not found"
   command -v grub-mkstandalone >/dev/null || fail "grub-mkstandalone not found — rebuild with --usb --rootfs (grub)"
-  command -v mkinitcpio >/dev/null || fail "mkinitcpio not found"
-  [[ -f $SHARE/mkinitcpio-install.conf ]] || fail "missing $SHARE/mkinitcpio-install.conf — rebuild the live USB"
   [[ -f $SHARE/grub-embed-install.cfg ]] || fail "missing $SHARE/grub-embed-install.cfg — rebuild the live USB"
 
   payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
@@ -264,16 +262,7 @@ install_persistent_root() {
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
 
-  kernel=$(uname -r)
-  printf '==> building USB-root initramfs (linux-asahi %s)\n' "$kernel"
   work=$(mktemp -d)
-  mkinitcpio -n \
-    -c "$SHARE/mkinitcpio-install.conf" \
-    -D /usr/lib/initcpio \
-    -D "$SHARE/initcpio" \
-    -k "$kernel" \
-    -g "$work/initramfs-linux-asahi.img"
-
   esp_mnt=$(mktemp -d)
   mount "$esp_part" "$esp_mnt"
   mkdir -p "$esp_mnt/EFI/BOOT" "$esp_mnt/grub"
@@ -286,13 +275,13 @@ install_persistent_root() {
     live_esp_mounted_by_us=1
   fi
   [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || fail "no vmlinuz-linux-asahi on the live ESP"
+  [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || fail "no initramfs-linux-asahi.img on the live ESP"
   cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-linux-asahi"
+  cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-linux-asahi.img"
   if (( live_esp_mounted_by_us == 1 )); then
     umount "$live_esp_mnt"
     rmdir "$live_esp_mnt"
   fi
-
-  cp "$work/initramfs-linux-asahi.img" "$esp_mnt/initramfs-linux-asahi.img"
 
   grub_cfg=$work/grub.cfg
   cat >"$grub_cfg" <<EOF

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -266,6 +266,10 @@ install_persistent_root() {
   printf 'UUID=%s /home btrfs subvol=@home,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
   printf 'UUID=%s /var/log btrfs subvol=@log,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
   printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
+  cat >"$root_mnt/etc/issue" <<'EOF'
+Omarchy Mac USB root (not live, not the desktop).
+Wi-Fi: nmtui Rescan, then Activate.
+EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
 

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -284,7 +284,8 @@ install_persistent_root() {
   [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || fail "no vmlinuz-linux-asahi on the live ESP"
   [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || fail "no initramfs-linux-asahi.img on the live ESP"
   cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-linux-asahi"
-  cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-linux-asahi.img"
+  # Unique name: NVMe ESP also has initramfs-linux-asahi.img (LUKS).
+  cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-omarchy-usb-root.img"
   if (( live_esp_mounted_by_us == 1 )); then
     umount "$live_esp_mnt"
     rmdir "$live_esp_mnt"
@@ -298,11 +299,11 @@ echo '========================================'
 set timeout=8
 set default=0
 
-search --no-floppy --file /initramfs-linux-asahi.img --set=root
+search --no-floppy --file /omarchy-usb-install --set=root
 
 menuentry 'Omarchy Mac (USB root)' {
   linux /vmlinuz-linux-asahi root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
-  initrd /initramfs-linux-asahi.img
+  initrd /initramfs-omarchy-usb-root.img
 }
 EOF
   cp "$grub_cfg" "$esp_mnt/grub/grub.cfg"

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -1,16 +1,15 @@
 #!/bin/bash
-# Clone this live USB onto another disk. Refuses NVMe, APFS, iBoot, Recovery,
-# and the live medium itself. Copies through the last partition (not the whole
-# source disk — a 16GB-class stick is often smaller than the live USB). When
-# this is the running live USB, keep the overlay lowerdir mounted. Not an
-# Omarchy install.
+# Clone this live USB, or install a persistent root onto another disk.
+# Refuses NVMe, APFS, iBoot, Recovery, and the live medium itself. Not
+# an Omarchy desktop install. No LUKS on this cut.
 set -euo pipefail
 
 APPLE_APFS=7c3457ef-0000-11aa-aa11-00306543ecac
 APPLE_IBOOT=69646961-6700-11aa-aa11-00306543ecac
 APPLE_RECOVERY=52637672-7900-11aa-aa11-00306543ecac
-# GPT backup header + entries after the last partition
 GPT_BACKUP_BYTES=$((34 * 512))
+ESP_MIB=512
+SHARE=/usr/local/share/omarchy-mac-iso
 
 fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
 
@@ -44,8 +43,6 @@ if overlay=$(overlay_payload_device); then
   [[ $overlay == "$live_partition" ]] && running_from_this_live_usb=1
 fi
 
-# Bytes covering every partition on $1, plus slack for a backup GPT.
-# lsblk -b SIZE is bytes; START is 512-byte sectors.
 copy_bytes_for_disk() {
   local disk=$1 name start size end=0
   while read -r name start size; do
@@ -90,76 +87,258 @@ payload_partition_on() {
   return 1
 }
 
-copy_bytes=$(copy_bytes_for_disk "$live_disk")
+esp_partition_on() {
+  local disk=$1 name fstype label
+  while read -r name fstype label; do
+    [[ $name == "$disk" ]] && continue
+    if [[ $label == OMARCHYISO || $fstype == vfat ]]; then
+      printf '/dev/%s\n' "$name"
+      return 0
+    fi
+  done < <(lsblk -ln -o NAME,FSTYPE,LABEL "/dev/$disk")
+  return 1
+}
 
-candidates=()
-while read -r name size model tran; do
-  [[ -z $name ]] && continue
-  [[ $name == nvme* ]] && continue
-  [[ $name == "$live_disk" ]] && continue
-  [[ ${tran:-} == nvme ]] && continue
-  disk_has_apple_partitions "$name" && continue
-  bytes=$(lsblk -dn -b -o SIZE "/dev/$name")
-  (( bytes >= copy_bytes )) || continue
-  candidates+=("$name  $size  ${model:-disk}  ${tran:-}")
-done < <(lsblk -dn -o NAME,SIZE,MODEL,TRAN)
-
-(( ${#candidates[@]} > 0 )) || fail "no eligible disks (need USB/SCSI >= ${copy_bytes} bytes, not NVMe, not the live USB)"
-
-choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Destroy ALL data on which disk?")
-[[ -n $choice ]] || fail "cancelled"
-target_name=${choice%% *}
-target_dev=/dev/$target_name
-
-[[ $target_name == nvme* ]] && fail "refusing NVMe"
-[[ $target_name == "$live_disk" ]] && fail "refusing the live USB"
-disk_has_apple_partitions "$target_name" && fail "refusing a disk with APFS/iBoot/Recovery"
-target_bytes=$(lsblk -dn -b -o SIZE "$target_dev")
-(( target_bytes >= copy_bytes )) || fail "$target_dev is too small (need $copy_bytes bytes)"
-
-gum confirm \
-  "This will DESTROY every partition on $target_dev (${choice#*  }). $copy_bytes bytes from $source_dev are copied onto it. Continue?" \
-  || fail "cancelled"
-
-unmount_disk "$target_dev"
-if (( running_from_this_live_usb == 1 )); then
-  unmount_disk "$source_dev" 1
-else
-  unmount_disk "$source_dev"
-fi
-sync
-
-printf '==> dd %s -> %s (%s bytes, through last partition)\n' \
-  "$source_dev" "$target_dev" "$copy_bytes"
-dd if="$source_dev" of="$target_dev" bs=4M iflag=count_bytes count="$copy_bytes" \
-  status=progress conv=fsync oflag=sync
-sync
-partprobe "$target_dev" 2>/dev/null || true
-if command -v sgdisk >/dev/null; then
-  sgdisk -e "$target_dev" || true
-fi
-partprobe "$target_dev" 2>/dev/null || true
-command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
-
-target_payload=""
-for _ in 1 2 3 4 5 6; do
-  target_payload=$(payload_partition_on "$target_name" || true)
-  [[ -n $target_payload ]] && break
-  sleep 1
-  partprobe "$target_dev" 2>/dev/null || true
-done
-if [[ -n $target_payload ]] && command -v btrfstune >/dev/null; then
-  printf '==> new btrfs UUID on %s (clone must not share the live fsid)\n' "$target_payload"
-  if command -v btrfs >/dev/null; then
-    btrfs device scan --forget "$target_payload" || true
+partition_node() {
+  local disk=$1 number=$2
+  if [[ -b /dev/${disk}${number} ]]; then
+    printf '/dev/%s%s\n' "$disk" "$number"
+  elif [[ -b /dev/${disk}p${number} ]]; then
+    printf '/dev/%sp%s\n' "$disk" "$number"
+  else
+    return 1
   fi
-  btrfstune -f -u "$target_payload"
-else
-  printf 'warning: no btrfs partition on %s yet; clone UUID was not rewritten\n' \
-    "$target_dev" >&2
-fi
+}
 
-printf '==> done. Unplug the live USB %s, cold-start, boot the target %s.\n' \
-  "$source_dev" "$target_dev"
-printf '    U-Boot: usb reset until usb storage lists that stick, then load usb 0:1 ...\n'
-lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
+wait_for_btrfs() {
+  local disk=$1 found="" i
+  for i in 1 2 3 4 5 6; do
+    found=$(payload_partition_on "$disk" || true)
+    [[ -n $found ]] && { printf '%s\n' "$found"; return 0; }
+    sleep 1
+    partprobe "/dev/$disk" 2>/dev/null || true
+  done
+  return 1
+}
+
+pick_target_disk() {
+  local min_bytes=$1 name size model tran bytes
+  candidates=()
+  while read -r name size model tran; do
+    [[ -z $name ]] && continue
+    [[ $name == nvme* ]] && continue
+    [[ $name == "$live_disk" ]] && continue
+    [[ ${tran:-} == nvme ]] && continue
+    disk_has_apple_partitions "$name" && continue
+    bytes=$(lsblk -dn -b -o SIZE "/dev/$name")
+    (( bytes >= min_bytes )) || continue
+    candidates+=("$name  $size  ${model:-disk}  ${tran:-}")
+  done < <(lsblk -dn -o NAME,SIZE,MODEL,TRAN)
+  (( ${#candidates[@]} > 0 )) || fail "no eligible disks (need USB/SCSI >= ${min_bytes} bytes, not NVMe, not the live USB)"
+  choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Destroy ALL data on which disk?")
+  [[ -n $choice ]] || fail "cancelled"
+  target_name=${choice%% *}
+  target_dev=/dev/$target_name
+  [[ $target_name == nvme* ]] && fail "refusing NVMe"
+  [[ $target_name == "$live_disk" ]] && fail "refusing the live USB"
+  disk_has_apple_partitions "$target_name" && fail "refusing a disk with APFS/iBoot/Recovery"
+}
+
+clone_live_usb() {
+  local copy_bytes target_payload
+  copy_bytes=$(copy_bytes_for_disk "$live_disk")
+  pick_target_disk "$copy_bytes"
+  gum confirm \
+    "This will DESTROY every partition on $target_dev (${choice#*  }). $copy_bytes bytes from $source_dev are copied onto it. Continue?" \
+    || fail "cancelled"
+
+  unmount_disk "$target_dev"
+  if (( running_from_this_live_usb == 1 )); then
+    unmount_disk "$source_dev" 1
+  else
+    unmount_disk "$source_dev"
+  fi
+  sync
+
+  printf '==> dd %s -> %s (%s bytes, through last partition)\n' \
+    "$source_dev" "$target_dev" "$copy_bytes"
+  dd if="$source_dev" of="$target_dev" bs=4M iflag=count_bytes count="$copy_bytes" \
+    status=progress conv=fsync oflag=sync
+  sync
+  partprobe "$target_dev" 2>/dev/null || true
+  if command -v sgdisk >/dev/null; then
+    sgdisk -e "$target_dev" || true
+  fi
+  partprobe "$target_dev" 2>/dev/null || true
+  command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
+
+  target_payload=$(wait_for_btrfs "$target_name" || true)
+  if [[ -n $target_payload ]] && command -v btrfstune >/dev/null; then
+    printf '==> new btrfs UUID on %s (clone must not share the live fsid)\n' "$target_payload"
+    if command -v btrfs >/dev/null; then
+      btrfs device scan --forget "$target_payload" || true
+    fi
+    btrfstune -f -u "$target_payload"
+  else
+    printf 'warning: no btrfs partition on %s yet; clone UUID was not rewritten\n' \
+      "$target_dev" >&2
+  fi
+
+  printf '==> done. Unplug the live USB %s, cold-start, boot the target %s.\n' \
+    "$source_dev" "$target_dev"
+  printf '    U-Boot: usb reset until usb storage lists that stick, then load usb 0:1 ...\n'
+  lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
+}
+
+install_persistent_root() {
+  local payload_bytes min_bytes source_esp esp_part root_part
+  local root_mnt esp_mnt live_esp_mnt kernel
+  local root_uuid esp_uuid grub_cfg work
+
+  command -v parted >/dev/null || fail "parted not found"
+  command -v mkfs.vfat >/dev/null || fail "mkfs.vfat not found — rebuild with --usb --rootfs (dosfstools)"
+  command -v mkfs.btrfs >/dev/null || fail "btrfs-progs not found"
+  command -v grub-mkstandalone >/dev/null || fail "grub-mkstandalone not found — rebuild with --usb --rootfs (grub)"
+  command -v mkinitcpio >/dev/null || fail "mkinitcpio not found"
+  [[ -f $SHARE/mkinitcpio-install.conf ]] || fail "missing $SHARE/mkinitcpio-install.conf — rebuild the live USB"
+
+  payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
+  min_bytes=$(( ESP_MIB * 1024 * 1024 + payload_bytes + 64 * 1024 * 1024 ))
+  pick_target_disk "$min_bytes"
+  gum confirm \
+    "This will DESTROY $target_dev (${choice#*  }) and install a persistent USB root (no overlay, no LUKS). Continue?" \
+    || fail "cancelled"
+
+  source_esp=$(esp_partition_on "$live_disk" || true)
+  [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
+
+  unmount_disk "$target_dev"
+  if (( running_from_this_live_usb == 1 )); then
+    unmount_disk "$source_dev" 1
+  fi
+  sync
+
+  printf '==> partitioning %s (512MiB ESP + btrfs root)\n' "$target_dev"
+  wipefs -a "$target_dev" 2>/dev/null || true
+  parted -s "$target_dev" mklabel gpt \
+    mkpart ESP fat32 1MiB "$((ESP_MIB + 1))MiB" \
+    set 1 esp on \
+    mkpart root btrfs "$((ESP_MIB + 1))MiB" 100%
+  partprobe "$target_dev" 2>/dev/null || true
+  command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
+  sleep 1
+
+  esp_part=$(partition_node "$target_name" 1) || fail "ESP partition did not appear on $target_dev"
+  root_part=$(partition_node "$target_name" 2) || fail "root partition did not appear on $target_dev"
+
+  printf '==> formatting ESP %s\n' "$esp_part"
+  mkfs.vfat -F 32 -n OMARCHYBOOT "$esp_part"
+
+  printf '==> copying payload %s -> %s\n' "$live_partition" "$root_part"
+  dd if="$live_partition" of="$root_part" bs=4M status=progress conv=fsync oflag=sync
+  sync
+  partprobe "$target_dev" 2>/dev/null || true
+  command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
+
+  root_mnt=$(mktemp -d)
+  mount -o subvol=@ "$root_part" "$root_mnt"
+  printf '==> btrfs resize max on %s\n' "$root_part"
+  btrfs filesystem resize max "$root_mnt"
+  btrfs filesystem label "$root_mnt" OMARCHYROOT
+  umount "$root_mnt"
+
+  if command -v btrfs >/dev/null; then
+    btrfs device scan --forget "$root_part" || true
+  fi
+  btrfstune -f -u "$root_part"
+  mount -o subvol=@ "$root_part" "$root_mnt"
+
+  root_uuid=$(blkid -s UUID -o value "$root_part")
+  [[ -n $root_uuid ]] || fail "no UUID on $root_part after btrfstune"
+
+  printf 'UUID=%s / btrfs subvol=@,compress=zstd:1 0 0\n' "$root_uuid" >"$root_mnt/etc/fstab"
+  printf 'UUID=%s /home btrfs subvol=@home,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
+  printf 'UUID=%s /var/log btrfs subvol=@log,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
+  printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
+  rm -f "$root_mnt/omarchy-mac-overlay-write"
+  : >"$root_mnt/etc/machine-id"
+
+  kernel=$(uname -r)
+  printf '==> building USB-root initramfs (linux-asahi %s)\n' "$kernel"
+  work=$(mktemp -d)
+  mkinitcpio -n \
+    -c "$SHARE/mkinitcpio-install.conf" \
+    -D /usr/lib/initcpio \
+    -D "$SHARE/initcpio" \
+    -k "$kernel" \
+    -g "$work/initramfs-linux-asahi.img"
+
+  esp_mnt=$(mktemp -d)
+  mount "$esp_part" "$esp_mnt"
+  mkdir -p "$esp_mnt/EFI/BOOT" "$esp_mnt/grub"
+
+  live_esp_mnt=$(findmnt -n -o TARGET "$source_esp" || true)
+  live_esp_mounted_by_us=0
+  if [[ -z $live_esp_mnt ]]; then
+    live_esp_mnt=$(mktemp -d)
+    mount -o ro "$source_esp" "$live_esp_mnt"
+    live_esp_mounted_by_us=1
+  fi
+  [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || fail "no vmlinuz-linux-asahi on the live ESP"
+  cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-linux-asahi"
+  if (( live_esp_mounted_by_us == 1 )); then
+    umount "$live_esp_mnt"
+    rmdir "$live_esp_mnt"
+  fi
+
+  cp "$work/initramfs-linux-asahi.img" "$esp_mnt/initramfs-linux-asahi.img"
+
+  grub_cfg=$work/grub.cfg
+  cat >"$grub_cfg" <<EOF
+echo '========================================'
+echo '  OMARCHY USB INSTALL (not live, not NVMe)'
+echo '========================================'
+set timeout=8
+set default=0
+
+search --no-floppy --file /initramfs-linux-asahi.img --set=root
+
+menuentry 'Omarchy Mac (USB root)' {
+  linux /vmlinuz-linux-asahi root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=7
+  initrd /initramfs-linux-asahi.img
+}
+EOF
+  cp "$grub_cfg" "$esp_mnt/grub/grub.cfg"
+  cp "$grub_cfg" "$esp_mnt/EFI/BOOT/grub.cfg"
+
+  grub-mkstandalone -O arm64-efi \
+    --fonts="" --locales="" --themes="" \
+    --install-modules="linux fat ext2 btrfs part_gpt search search_label search_fs_uuid search_fs_file echo normal configfile gzio reboot sleep" \
+    --modules="part_gpt fat search search_fs_file configfile linux echo normal" \
+    -o "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" \
+    "boot/grub/grub.cfg=$SHARE/grub-embed.cfg"
+
+  esp_uuid=$(blkid -s UUID -o value "$esp_part")
+  printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"
+
+  sync
+  umount "$esp_mnt"
+  umount "$root_mnt"
+  rm -rf "$esp_mnt" "$root_mnt" "$work"
+
+  printf '==> done. Unplug the live USB %s, cold-start, boot the installed disk %s.\n' \
+    "$source_dev" "$target_dev"
+  printf '    U-Boot: usb reset until usb storage lists that stick, then load usb 0:1 ...\n'
+  lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
+}
+
+action=$(gum choose --header "Omarchy Mac live USB" \
+  "Install to a disk (persistent root, wipes it)" \
+  "Clone this live USB onto another stick")
+[[ -n $action ]] || fail "cancelled"
+
+case $action in
+  Install*) install_persistent_root ;;
+  Clone*) clone_live_usb ;;
+  *) fail "unknown action" ;;
+esac

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -201,6 +201,7 @@ install_persistent_root() {
   command -v grub-mkstandalone >/dev/null || fail "grub-mkstandalone not found — rebuild with --usb --rootfs (grub)"
   command -v mkinitcpio >/dev/null || fail "mkinitcpio not found"
   [[ -f $SHARE/mkinitcpio-install.conf ]] || fail "missing $SHARE/mkinitcpio-install.conf — rebuild the live USB"
+  [[ -f $SHARE/grub-embed-install.cfg ]] || fail "missing $SHARE/grub-embed-install.cfg — rebuild the live USB"
 
   payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
   min_bytes=$(( ESP_MIB * 1024 * 1024 + payload_bytes + 64 * 1024 * 1024 ))
@@ -310,13 +311,14 @@ menuentry 'Omarchy Mac (USB root)' {
 EOF
   cp "$grub_cfg" "$esp_mnt/grub/grub.cfg"
   cp "$grub_cfg" "$esp_mnt/EFI/BOOT/grub.cfg"
+  : >"$esp_mnt/omarchy-usb-install"
 
   grub-mkstandalone -O arm64-efi \
     --fonts="" --locales="" --themes="" \
     --install-modules="linux fat ext2 btrfs part_gpt search search_label search_fs_uuid search_fs_file echo normal configfile gzio reboot sleep" \
     --modules="part_gpt fat search search_fs_file configfile linux echo normal" \
     -o "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" \
-    "boot/grub/grub.cfg=$SHARE/grub-embed.cfg"
+    "boot/grub/grub.cfg=$SHARE/grub-embed-install.cfg"
 
   esp_uuid=$(blkid -s UUID -o value "$esp_part")
   printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -51,9 +51,10 @@ stick booted to autologin root, `gum 2.0.0`, `fnmode=1`. Proven from a
 booted live USB the same day: 14.5G stick → Lexar; U-Boot skipped
 `05dc:c753` until `usb reset` twice, then the Lexar booted. Overlay +
 `switch_root`, systemd userspace, and Wi-Fi association are done
-(2026-08-23). Partition install (ESP + persistent USB root, no overlay)
-is in tree, not yet proven on metal. Not yet: LUKS, Omarchy packages, or
-install onto internal NVMe.
+(2026-08-23). Partition install (ESP + persistent USB root, no overlay) is proven on
+metal (2026-08-24): 14.5G stick, GRUB `Omarchy Mac (USB root)`,
+`omarchy-usb-wait` mounted the new UUID, hostname `omarchy-mac`. Not yet:
+LUKS, Omarchy packages, or install onto internal NVMe.
 
 ## Architecture: one rootfs, two front doors
 

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -51,7 +51,9 @@ stick booted to autologin root, `gum 2.0.0`, `fnmode=1`. Proven from a
 booted live USB the same day: 14.5G stick → Lexar; U-Boot skipped
 `05dc:c753` until `usb reset` twice, then the Lexar booted. Overlay +
 `switch_root`, systemd userspace, and Wi-Fi association are done
-(2026-08-23). Not yet: LUKS, Omarchy packages, or install onto internal NVMe.
+(2026-08-23). Partition install (ESP + persistent USB root, no overlay)
+is in tree, not yet proven on metal. Not yet: LUKS, Omarchy packages, or
+install onto internal NVMe.
 
 ## Architecture: one rootfs, two front doors
 

--- a/test/unit
+++ b/test/unit
@@ -96,6 +96,10 @@ check "rootfs pacstraps dosfstools and grub" grep -q dosfstools \
   "${repo_root}/builder/build-rootfs.sh"
 check "usb image embeds grub-embed.cfg" grep -q grub-embed.cfg \
   "${repo_root}/builder/build-usb-image.sh"
+check "usb image builds install initramfs" grep -q initramfs-linux-asahi.img \
+  "${repo_root}/builder/build-usb-image.sh"
+check "install copies initramfs from live ESP" grep -q 'initramfs-linux-asahi.img on the live ESP' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 

--- a/test/unit
+++ b/test/unit
@@ -82,6 +82,10 @@ check "sh -n omarchy-mac-install" bash -n \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "usb grub embed loads /grub/grub.cfg" grep -q 'configfile /grub/grub.cfg' \
   "${repo_root}/configs/usb/grub-embed.cfg"
+check "live GRUB searches omarchy-usb-live not NVMe grub.cfg" grep -q /omarchy-usb-live \
+  "${repo_root}/configs/usb/grub-embed.cfg"
+check "install GRUB searches omarchy-usb-install" grep -q /omarchy-usb-install \
+  "${repo_root}/configs/usb/grub-embed-install.cfg"
 check "install initramfs waits for USB root" grep -q OMARCHYROOT \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-wait"
 check "install initramfs lists dwc3_apple" grep -q dwc3_apple \

--- a/test/unit
+++ b/test/unit
@@ -74,8 +74,24 @@ check "install script keeps overlay lowerdir mounted" grep -q omarchy-mac-overla
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install script rewrites clone btrfs UUID" grep -q 'btrfstune -f -u' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install script offers persistent root install" grep -q 'Install to a disk' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install script labels the installed root OMARCHYROOT" grep -q OMARCHYROOT \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "sh -n omarchy-mac-install" bash -n \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "usb grub embed loads /grub/grub.cfg" grep -q 'configfile /grub/grub.cfg' \
+  "${repo_root}/configs/usb/grub-embed.cfg"
+check "install initramfs waits for USB root" grep -q OMARCHYROOT \
+  "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-wait"
+check "install initramfs lists dwc3_apple" grep -q dwc3_apple \
+  "${repo_root}/configs/usb-initcpio/mkinitcpio-install.conf"
+check "sh -n omarchy-usb-wait" sh -n \
+  "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-wait"
+check "rootfs pacstraps dosfstools and grub" grep -q dosfstools \
+  "${repo_root}/builder/build-rootfs.sh"
+check "usb image embeds grub-embed.cfg" grep -q grub-embed.cfg \
+  "${repo_root}/builder/build-usb-image.sh"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 

--- a/test/unit
+++ b/test/unit
@@ -100,6 +100,8 @@ check "usb image builds install initramfs" grep -q initramfs-linux-asahi.img \
   "${repo_root}/builder/build-usb-image.sh"
 check "install copies initramfs from live ESP" grep -q 'initramfs-linux-asahi.img on the live ESP' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install initrd name is unique vs NVMe" grep -q initramfs-omarchy-usb-root.img \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 


### PR DESCRIPTION
## Summary

`omarchy-mac-install` can install a persistent root onto another USB: 512MiB ESP + btrfs filling the rest, copy the live payload, `btrfs resize max`, GRUB with `root=UUID=`. Not a live overlay, not LUKS, not Omarchy packages, not NVMe.

GRUB searches USB-only marker files (`/omarchy-usb-live`, `/omarchy-usb-install`) and a unique initrd name so it cannot load the NVMe ESP's `grub.cfg` or `initramfs-linux-asahi.img`.

Proven on an M2 Max: 14.5G stick, GRUB `Omarchy Mac (USB root)`, `omarchy-usb-wait` mounted the new UUID, systemd mounted `OMARCHYBOOT`/`OMARCHYROOT`, autologin `root@omarchy-mac`.