### PR TITLE
Install into GPT free space without wiping the disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ is not defined. Live GRUB prints `OMARCHY USB GRUB`; installed GRUB prints
 `OMARCHY USB INSTALL` / menu `Omarchy Mac (USB root)`. Omarchy Linux /
 Advanced options means you are on NVMe.
 
-Wi-Fi: nmtui Rescan until SSIDs appear, then Activate or
-`nmcli device wifi connect 'SSID' password 'PSK'`.
+Wi-Fi: nmtui Rescan until SSIDs appear (a few rescans is normal), then
+Activate. On the persistent USB root (2026-08-24) that was enough for
+`ping www.google.com`; nmcli is optional.
 
 ### Clone vs install
 
@@ -137,9 +138,12 @@ GUIDs):
   `gum 2.0.0`, `fnmode=1`.
 - **Install (wipe USB)** — GPT ESP (`OMARCHYBOOT`) + btrfs root filling the
   disk. Proven on an M2 Max (2026-08-24): 14.5G stick, autologin
-  `root@omarchy-mac`.
+  `root@omarchy-mac`, nmtui Rescan then Wi-Fi ping. Warm USB boot worked.
+  GRUB must search `/omarchy-usb-install`, not `/initramfs-linux-asahi.img`
+  (that file is the NVMe LUKS initramfs).
 - **Install into free space** — `parted mkpart` in an existing GPT hole only.
-  Never `mklabel`/`wipefs`. Refuses to run if there is no hole ≥ payload
-  (this machine's NVMe has none until APFS is shrunk **from macOS**). Writes
-  `grub/custom.cfg` on the existing ESP; does not replace `BOOTAA64.EFI`.
-  Loopback-tested; not yet proven on metal.
+  Never `mklabel`/`wipefs`. Proven on the Lexar hole (keep live
+  `OMARCHYISO`/`OMARCHYLIVE`, new `OMARCHYROOT` 11.4G). NVMe still has no
+  hole until APFS is shrunk **from macOS**. Writes `grub/custom.cfg` on the
+  existing ESP; unique `vmlinuz-omarchy-usb-root` / initrd names; does not
+  replace `BOOTAA64.EFI`.

--- a/README.md
+++ b/README.md
@@ -135,10 +135,11 @@ GUIDs):
   unless this *is* the running live overlay. Rewrites the clone btrfs UUID.
   Proven from Omarchy and from the live USB (2026-08-23): Lexar ↔ 14.5G stick,
   `gum 2.0.0`, `fnmode=1`.
-- **Install** — GPT ESP (`OMARCHYBOOT`) + btrfs root (`OMARCHYROOT`) filling
-  the disk, copy the payload, `btrfs resize max`, GRUB with `root=UUID=`.
-  Persistent root, no overlay, no LUKS, not Omarchy packages. Do not name
-  the initrd `initramfs-linux-asahi.img` (NVMe ESP has that; GRUB then
-  loads the LUKS initramfs). Proven on an M2 Max (2026-08-24): 14.5G stick,
-  `omarchy-usb-wait` mounted `UUID=e68e2508-…`, systemd mounted
-  `OMARCHYBOOT`/`OMARCHYROOT`, autologin `root@omarchy-mac`.
+- **Install (wipe USB)** — GPT ESP (`OMARCHYBOOT`) + btrfs root filling the
+  disk. Proven on an M2 Max (2026-08-24): 14.5G stick, autologin
+  `root@omarchy-mac`.
+- **Install into free space** — `parted mkpart` in an existing GPT hole only.
+  Never `mklabel`/`wipefs`. Refuses to run if there is no hole ≥ payload
+  (this machine's NVMe has none until APFS is shrunk **from macOS**). Writes
+  `grub/custom.cfg` on the existing ESP; does not replace `BOOTAA64.EFI`.
+  Loopback-tested; not yet proven on metal.

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -78,6 +78,10 @@ install -d "$mnt/etc/systemd/system"
 install -d "$mnt/usr/local/sbin"
 install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-install" \
   "$mnt/usr/local/sbin/omarchy-mac-install"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" \
+  "$mnt/usr/local/share/omarchy-mac-iso/omarchy-mac-disk.sh"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" \
+  "$mnt/usr/local/sbin/omarchy-mac-disk.sh"
 install -d "$mnt/usr/local/share/omarchy-mac-iso/initcpio/hooks"
 install -d "$mnt/usr/local/share/omarchy-mac-iso/initcpio/install"
 install -m644 "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" \

--- a/configs/usb/grub.cfg
+++ b/configs/usb/grub.cfg
@@ -13,3 +13,7 @@ menuentry 'Omarchy Mac live (USB)' {
   linux /vmlinuz-linux-asahi loglevel=3
   initrd /initramfs-omarchy-usb.img
 }
+
+if [ -f /grub/custom.cfg ]; then
+  source /grub/custom.cfg
+fi

--- a/configs/usb/rootfs/omarchy-mac-disk.sh
+++ b/configs/usb/rootfs/omarchy-mac-disk.sh
@@ -66,6 +66,44 @@ disk_is_nvme() {
   [[ $name == nvme* ]]
 }
 
+device_mib() {
+  local dev=$1 bytes
+  if [[ -b $dev ]]; then
+    bytes=$(( $(cat /sys/block/"${dev#/dev/}"/size) * 512 ))
+  else
+    bytes=$(stat -c %s "$dev")
+  fi
+  printf '%s\n' $(( bytes / 1024 / 1024 ))
+}
+
+# Move backup GPT to the real end of a USB image that was dd'd onto a
+# larger stick. Never run this on NVMe / Apple partitions.
+grow_gpt_to_device() {
+  local dev=$1 name=${1#/dev/}
+  if [[ -b $dev ]]; then
+    disk_is_nvme "$name" && return 0
+    disk_has_apple_partitions "$name" && return 0
+  fi
+  if command -v sgdisk >/dev/null; then
+    sgdisk -e "$dev" >/dev/null
+  else
+    printf 'Fix\n' | parted ---pretend-input-tty "$dev" print >/dev/null || true
+  fi
+}
+
+# start size -> start size end, clamped so parted does not treat the
+# exact device size as "outside of the device".
+clamp_free_region() {
+  local start=$1 size=$2 disk_mib=$3 end max_end
+  end=$(( start + size ))
+  max_end=$(( disk_mib - 2 ))
+  (( max_end > start )) || return 1
+  (( end > max_end )) && end=$max_end
+  size=$(( end - start ))
+  (( size >= MIN_FREE_MIB )) || return 1
+  printf '%s %s %s\n' "$start" "$size" "$end"
+}
+
 # Existing System ESP: GPT ESP type, or FAT labelled EFI*.
 existing_esp_on() {
   local disk=$1 name type label

--- a/configs/usb/rootfs/omarchy-mac-disk.sh
+++ b/configs/usb/rootfs/omarchy-mac-disk.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Partition helpers for omarchy-mac-install. Safe to source from tests.
+# Never mklabel/wipefs a disk that already has Apple GPT types.
+
+APPLE_APFS=7c3457ef-0000-11aa-aa11-00306543ecac
+APPLE_IBOOT=69646961-6700-11aa-aa11-00306543ecac
+APPLE_RECOVERY=52637672-7900-11aa-aa11-00306543ecac
+ESP_PARTTYPE=c12a7328-f81f-11d2-ba4b-00a0c93ec93b
+GPT_BACKUP_SECTORS=34
+# Skip GPT alignment slivers
+MIN_FREE_MIB=64
+
+disk_has_apple_partitions() {
+  local disk=$1 type
+  while read -r type; do
+    [[ -z $type ]] && continue
+    type=${type,,}
+    [[ $type == "$APPLE_APFS" || $type == "$APPLE_IBOOT" || $type == "$APPLE_RECOVERY" ]] && return 0
+  done < <(lsblk -n -o PARTTYPE "/dev/$disk" 2>/dev/null)
+  return 1
+}
+
+# Snapshot "name type" lines for Apple partitions on $1 (path or NAME).
+apple_partition_snapshot() {
+  local dev=$1 name type
+  while read -r name type; do
+    [[ -z $type ]] && continue
+    type=${type,,}
+    if [[ $type == "$APPLE_APFS" || $type == "$APPLE_IBOOT" || $type == "$APPLE_RECOVERY" ]]; then
+      printf '%s %s\n' "$name" "$type"
+    fi
+  done < <(lsblk -n -o NAME,PARTTYPE "$dev" 2>/dev/null)
+}
+
+# Print "start_mib size_mib" for each Free Space region on a parted device
+# (block device or image file). start/size are in MiB.
+list_free_regions() {
+  local dev=$1 start end size rest
+  while read -r start end size rest; do
+    [[ $rest == *Free* ]] || continue
+    start=${start%s}
+    size=${size%s}
+    # parted unit MiB prints e.g. 1025MiB — strip the unit
+    start=${start%MiB}
+    size=${size%MiB}
+    start=${start%%.*}
+    size=${size%%.*}
+    [[ -z $start || -z $size ]] && continue
+    (( size >= MIN_FREE_MIB )) || continue
+    printf '%s %s\n' "$start" "$size"
+  done < <(parted -s "$dev" unit MiB print free 2>/dev/null)
+}
+
+largest_free_region() {
+  local dev=$1 start size best_start=0 best_size=0
+  while read -r start size; do
+    (( size > best_size )) && { best_size=$size; best_start=$start; }
+  done < <(list_free_regions "$dev")
+  (( best_size > 0 )) || return 1
+  printf '%s %s\n' "$best_start" "$best_size"
+}
+
+disk_is_nvme() {
+  local name=$1
+  [[ $name == nvme* ]]
+}
+
+# Existing System ESP: GPT ESP type, or FAT labelled EFI*.
+existing_esp_on() {
+  local disk=$1 name type label
+  while read -r name type label; do
+    [[ $name == "$disk" ]] && continue
+    type=${type,,}
+    if [[ $type == "$ESP_PARTTYPE" ]]; then
+      printf '/dev/%s\n' "$name"
+      return 0
+    fi
+    if [[ ${label,,} == efi* || $label == OMARCHYISO || $label == OMARCHYBOOT ]]; then
+      printf '/dev/%s\n' "$name"
+      return 0
+    fi
+  done < <(lsblk -n -o NAME,PARTTYPE,LABEL "/dev/$disk" 2>/dev/null)
+  return 1
+}
+
+partition_names_on() {
+  local disk=$1 name
+  while read -r name; do
+    [[ $name == "$disk" ]] && continue
+    printf '%s\n' "$name"
+  done < <(lsblk -ln -o NAME "/dev/$disk" 2>/dev/null)
+}
+
+# After mkpart, the new node is the NAME that was not in $before_list.
+new_partition_node() {
+  local disk=$1 before=$2 name
+  while read -r name; do
+    [[ $name == "$disk" ]] && continue
+    printf '%s\n' "$before" | grep -qx "$name" && continue
+    printf '/dev/%s\n' "$name"
+    return 0
+  done < <(lsblk -ln -o NAME "/dev/$disk")
+  return 1
+}

--- a/configs/usb/rootfs/omarchy-mac-disk.sh
+++ b/configs/usb/rootfs/omarchy-mac-disk.sh
@@ -35,20 +35,21 @@ apple_partition_snapshot() {
 # Print "start_mib size_mib" for each Free Space region on a parted device
 # (block device or image file). start/size are in MiB.
 list_free_regions() {
-  local dev=$1 start end size rest
+  local dev=$1 start end size rest found=0
   while read -r start end size rest; do
-    [[ $rest == *Free* ]] || continue
+    [[ $rest == *"Free Space"* ]] || continue
     start=${start%s}
     size=${size%s}
-    # parted unit MiB prints e.g. 1025MiB — strip the unit
     start=${start%MiB}
     size=${size%MiB}
     start=${start%%.*}
     size=${size%%.*}
-    [[ -z $start || -z $size ]] && continue
+    [[ $start =~ ^[0-9]+$ && $size =~ ^[0-9]+$ ]] || continue
     (( size >= MIN_FREE_MIB )) || continue
     printf '%s %s\n' "$start" "$size"
+    found=1
   done < <(parted -s "$dev" unit MiB print free 2>/dev/null)
+  (( found == 1 ))
 }
 
 largest_free_region() {

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -56,15 +56,21 @@ fi
 
 if [[ ${1:-} == --dry-run ]]; then
   printf '==> dry-run: free GPT regions (start_mib size_mib)\n'
-  while read -r name model; do
+  while read -r name size_h model; do
     [[ -z $name ]] && continue
-    printf '%s (%s)\n' "$name" "$model"
-    if list=$(list_free_regions "/dev/$name"); then
-      printf '%s\n' "$list" | awk '{ printf "  %sMiB +%sMiB\n", $1, $2 }'
+    bytes=$(lsblk -dn -b -o SIZE "/dev/$name")
+    (( bytes >= 8 * 1024 * 1024 * 1024 )) || continue
+    printf '%s (%s, %s)\n' "$name" "$model" "$size_h"
+    list=$(list_free_regions "/dev/$name" || true)
+    if [[ -n $list ]]; then
+      printf '%s\n' "$list" | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ {
+        printf "  %sMiB +%sMiB\n", $1, $2
+      }'
     else
-      printf '  (no region >= %sMiB)\n' "$MIN_FREE_MIB"
+      printf '  (no region >= %sMiB — shrink APFS from macOS, never from Linux)\n' \
+        "$MIN_FREE_MIB"
     fi
-  done < <(lsblk -dn -o NAME,MODEL)
+  done < <(lsblk -dn -o NAME,SIZE,MODEL)
   exit 0
 fi
 
@@ -364,6 +370,8 @@ install_into_free_space() {
   candidates=()
   while read -r name size model tran; do
     [[ -z $name ]] && continue
+    bytes=$(lsblk -dn -b -o SIZE "/dev/$name")
+    (( bytes >= 8 * 1024 * 1024 * 1024 )) || continue
     [[ $name == "$live_disk" ]] && (( running_from_this_live_usb == 1 )) && continue
     region=$(largest_free_region "/dev/$name" || true)
     [[ -n $region ]] || continue

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -1,17 +1,24 @@
 #!/bin/bash
-# Clone this live USB, or install a persistent root onto another disk.
-# Refuses NVMe, APFS, iBoot, Recovery, and the live medium itself. Not
-# an Omarchy desktop install. No LUKS on this cut.
+# Clone this live USB, wipe-install a USB, or install into GPT free space
+# (never mklabel a disk that already has Apple partitions). Not an Omarchy
+# desktop install. No LUKS on this cut.
 set -euo pipefail
 
-APPLE_APFS=7c3457ef-0000-11aa-aa11-00306543ecac
-APPLE_IBOOT=69646961-6700-11aa-aa11-00306543ecac
-APPLE_RECOVERY=52637672-7900-11aa-aa11-00306543ecac
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
 GPT_BACKUP_BYTES=$((34 * 512))
 ESP_MIB=512
 SHARE=/usr/local/share/omarchy-mac-iso
-
-fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+here=$(cd "$(dirname "$0")" && pwd)
+if [[ -f $SHARE/omarchy-mac-disk.sh ]]; then
+  # shellcheck source=/dev/null
+  source "$SHARE/omarchy-mac-disk.sh"
+elif [[ -f $here/omarchy-mac-disk.sh ]]; then
+  # shellcheck source=/dev/null
+  source "$here/omarchy-mac-disk.sh"
+else
+  fail "omarchy-mac-disk.sh not found"
+fi
 
 [[ $EUID == 0 ]] || fail "run as root"
 command -v gum >/dev/null || fail "gum not found"
@@ -47,6 +54,20 @@ if overlay=$(overlay_payload_device); then
   [[ $overlay == "$live_partition" ]] && running_from_this_live_usb=1
 fi
 
+if [[ ${1:-} == --dry-run ]]; then
+  printf '==> dry-run: free GPT regions (start_mib size_mib)\n'
+  while read -r name model; do
+    [[ -z $name ]] && continue
+    printf '%s (%s)\n' "$name" "$model"
+    if list=$(list_free_regions "/dev/$name"); then
+      printf '%s\n' "$list" | awk '{ printf "  %sMiB +%sMiB\n", $1, $2 }'
+    else
+      printf '  (no region >= %sMiB)\n' "$MIN_FREE_MIB"
+    fi
+  done < <(lsblk -dn -o NAME,MODEL)
+  exit 0
+fi
+
 copy_bytes_for_disk() {
   local disk=$1 name start size end=0
   while read -r name start size; do
@@ -56,16 +77,6 @@ copy_bytes_for_disk() {
   done < <(lsblk -lnb -o NAME,START,SIZE "/dev/$disk")
   (( end > 0 )) || fail "no partitions on /dev/$disk"
   printf '%s\n' $(( end + GPT_BACKUP_BYTES ))
-}
-
-disk_has_apple_partitions() {
-  local disk=$1 type
-  while read -r type; do
-    [[ -z $type ]] && continue
-    type=${type,,}
-    [[ $type == "$APPLE_APFS" || $type == "$APPLE_IBOOT" || $type == "$APPLE_RECOVERY" ]] && return 0
-  done < <(lsblk -n -o PARTTYPE "/dev/$disk")
-  return 1
 }
 
 unmount_disk() {
@@ -335,13 +346,191 @@ EOF
   lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
 }
 
+install_into_free_space() {
+  local payload_bytes min_bytes name size model tran bytes
+  local hole_start hole_size hole_end
+  local before_names before_apple backup
+  local root_part root_mnt esp_part esp_mnt
+  local root_uuid esp_uuid live_esp_mnt live_esp_mounted_by_us
+  local created_parts=()
+
+  command -v parted >/dev/null || fail "parted not found"
+  [[ -f $SHARE/grub-embed-install.cfg ]] || fail "missing $SHARE/grub-embed-install.cfg"
+
+  payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
+  min_bytes=$(( payload_bytes + 64 * 1024 * 1024 ))
+  min_mib=$(( (min_bytes + 1024 * 1024 - 1) / (1024 * 1024) ))
+
+  candidates=()
+  while read -r name size model tran; do
+    [[ -z $name ]] && continue
+    [[ $name == "$live_disk" ]] && (( running_from_this_live_usb == 1 )) && continue
+    region=$(largest_free_region "/dev/$name" || true)
+    [[ -n $region ]] || continue
+    read -r hole_start hole_size <<<"$region"
+    (( hole_size >= min_mib )) || continue
+    extra=""
+    disk_has_apple_partitions "$name" && extra=" (keeps APFS)"
+    disk_is_nvme "$name" && extra="${extra} nvme"
+    candidates+=("$name  ${hole_size}MiB free at ${hole_start}MiB  ${model:-disk}${extra}")
+  done < <(lsblk -dn -o NAME,SIZE,MODEL,TRAN)
+
+  (( ${#candidates[@]} > 0 )) || fail "no disk has >= ${min_mib}MiB free GPT space. Shrink APFS from macOS (never from Linux), then retry."
+
+  choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Install into which free region? Existing partitions stay.")
+  [[ -n $choice ]] || fail "cancelled"
+  target_name=${choice%% *}
+  target_dev=/dev/$target_name
+  region=$(largest_free_region "$target_dev")
+  read -r hole_start hole_size <<<"$region"
+  hole_end=$(( hole_start + hole_size ))
+  # Leave 1MiB at the end of the hole for GPT backup slack on some tools
+  (( hole_end > hole_start + min_mib )) || fail "free region shrank"
+
+  printf '==> selected %s hole %sMiB-%sMiB (%sMiB)\n' \
+    "$target_dev" "$hole_start" "$hole_end" "$hole_size"
+  printf '==> confirm (arrow keys, then enter)\n'
+  gum confirm \
+    "Create ONE new partition on $target_dev from ${hole_start}MiB to ${hole_end}MiB. APFS/iBoot/Recovery and all existing partitions stay. No mklabel, no LUKS. Continue?" \
+    || fail "cancelled"
+
+  if disk_has_apple_partitions "$target_name" || disk_is_nvme "$target_name"; then
+    [[ -z ${OMARCHY_INSTALL_DRY_RUN:-} ]] || true
+  fi
+
+  if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
+    printf 'dry-run: parted %s mkpart root btrfs %sMiB %sMiB\n' \
+      "$target_dev" "$hole_start" "$hole_end"
+    printf 'dry-run: would NOT mklabel or wipefs\n'
+    return 0
+  fi
+
+  source_esp=$(esp_partition_on "$live_disk" || true)
+  [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
+  esp_part=$(existing_esp_on "$target_name" || true)
+  [[ -n $esp_part ]] || fail "$target_dev has no ESP; will not create one next to APFS"
+
+  backup=$(mktemp /tmp/omarchy-gpt-${target_name}.XXXXXX)
+  if command -v sfdisk >/dev/null; then
+    sfdisk --dump "$target_dev" >"$backup"
+    printf '==> GPT dump saved at %s\n' "$backup"
+  fi
+
+  before_apple=$(apple_partition_snapshot "$target_dev")
+  before_names=$(partition_names_on "$target_name")
+
+  printf '==> mkpart root on %s (%sMiB-%sMiB)\n' "$target_dev" "$hole_start" "$hole_end"
+  parted -s "$target_dev" mkpart root btrfs "${hole_start}MiB" "${hole_end}MiB"
+  partprobe "$target_dev" 2>/dev/null || true
+  command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
+  sleep 1
+
+  after_apple=$(apple_partition_snapshot "$target_dev")
+  if [[ $before_apple != "$after_apple" ]]; then
+    printf 'error: Apple partition types changed — aborting\n' >&2
+    printf 'before:\n%s\nafter:\n%s\n' "$before_apple" "$after_apple" >&2
+    exit 1
+  fi
+
+  root_part=$(new_partition_node "$target_name" "$before_names") \
+    || fail "could not find the new partition on $target_dev"
+  created_parts+=("$root_part")
+  printf '==> new partition %s\n' "$root_part"
+
+  printf '==> copying payload %s -> %s\n' "$live_partition" "$root_part"
+  dd if="$live_partition" of="$root_part" bs=4M status=progress conv=fsync oflag=sync
+  sync
+  partprobe "$target_dev" 2>/dev/null || true
+
+  root_mnt=$(mktemp -d)
+  mount -o subvol=@ "$root_part" "$root_mnt"
+  btrfs filesystem resize max "$root_mnt"
+  btrfs filesystem label "$root_mnt" OMARCHYROOT
+  umount "$root_mnt"
+  if command -v btrfs >/dev/null; then
+    btrfs device scan --forget "$root_part" || true
+  fi
+  btrfstune -f -u "$root_part"
+  mount -o subvol=@ "$root_part" "$root_mnt"
+  root_uuid=$(blkid -s UUID -o value "$root_part")
+  [[ -n $root_uuid ]] || fail "no UUID on $root_part"
+
+  printf 'UUID=%s / btrfs subvol=@,compress=zstd:1 0 0\n' "$root_uuid" >"$root_mnt/etc/fstab"
+  printf 'UUID=%s /home btrfs subvol=@home,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
+  printf 'UUID=%s /var/log btrfs subvol=@log,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
+  printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
+  cat >"$root_mnt/etc/issue" <<'EOF'
+Omarchy Mac USB root (not live, not the desktop).
+Wi-Fi: nmtui Rescan, then Activate.
+EOF
+  rm -f "$root_mnt/omarchy-mac-overlay-write"
+  : >"$root_mnt/etc/machine-id"
+
+  esp_mnt=$(findmnt -n -o TARGET "$esp_part" || true)
+  esp_mounted_by_us=0
+  if [[ -z $esp_mnt ]]; then
+    esp_mnt=$(mktemp -d)
+    mount "$esp_part" "$esp_mnt"
+    esp_mounted_by_us=1
+  fi
+
+  live_esp_mnt=$(findmnt -n -o TARGET "$source_esp" || true)
+  live_esp_mounted_by_us=0
+  if [[ -z $live_esp_mnt ]]; then
+    live_esp_mnt=$(mktemp -d)
+    mount -o ro "$source_esp" "$live_esp_mnt"
+    live_esp_mounted_by_us=1
+  fi
+  [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || fail "no vmlinuz on live ESP"
+  [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || fail "no initramfs-linux-asahi.img on live ESP"
+  cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-linux-asahi"
+  cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-omarchy-usb-root.img"
+  if (( live_esp_mounted_by_us == 1 )); then
+    umount "$live_esp_mnt"
+    rmdir "$live_esp_mnt"
+  fi
+
+  mkdir -p "$esp_mnt/grub"
+  cat >"$esp_mnt/grub/custom.cfg" <<EOF
+menuentry 'Omarchy Mac (new root $root_uuid)' {
+  search --no-floppy --file /initramfs-omarchy-usb-root.img --set=root
+  linux /vmlinuz-linux-asahi root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
+  initrd /initramfs-omarchy-usb-root.img
+}
+EOF
+  # Standalone USB GRUB sources this from /grub/grub.cfg.
+  if [[ -f $esp_mnt/grub/grub.cfg ]] && ! grep -q custom.cfg "$esp_mnt/grub/grub.cfg"; then
+    printf '\nif [ -f /grub/custom.cfg ]; then source /grub/custom.cfg; fi\n' \
+      >>"$esp_mnt/grub/grub.cfg"
+  fi
+
+  esp_uuid=$(blkid -s UUID -o value "$esp_part")
+  printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"
+
+  sync
+  umount "$root_mnt"
+  if (( esp_mounted_by_us == 1 )); then
+    umount "$esp_mnt"
+    rmdir "$esp_mnt"
+  fi
+  rmdir "$root_mnt" 2>/dev/null || true
+
+  printf '==> done. Did not mklabel %s. New root %s UUID=%s\n' \
+    "$target_dev" "$root_part" "$root_uuid"
+  printf '    Boot via existing ESP %s (custom.cfg). GPT dump: %s\n' \
+    "$esp_part" "$backup"
+  lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
+}
+
 action=$(gum choose --header "Omarchy Mac live USB" \
-  "Install to a disk (persistent root, wipes it)" \
+  "Install into free space (keeps existing partitions)" \
+  "Install to a blank USB (wipes the whole disk)" \
   "Clone this live USB onto another stick")
 [[ -n $action ]] || fail "cancelled"
 
 case $action in
-  Install*) install_persistent_root ;;
+  "Install into free space"*) install_into_free_space ;;
+  "Install to a blank USB"*) install_persistent_root ;;
   Clone*) clone_live_usb ;;
   *) fail "unknown action" ;;
 esac

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -465,17 +465,25 @@ install_into_free_space() {
   dd if="$live_partition" of="$root_part" bs=4M status=progress conv=fsync oflag=sync
   sync
   partprobe "$target_dev" 2>/dev/null || true
+  command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
+
+  # dd copies the live UUID; udisks will remount it. Unique UUID first.
+  for _ in 1 2 3 4 5 6; do
+    m=$(findmnt -n -o TARGET "$root_part" || true)
+    [[ -z $m ]] && break
+    umount "$m" || umount -l "$m" || true
+    sleep 0.5
+  done
+  findmnt -n "$root_part" >/dev/null && fail "$root_part still mounted; cannot btrfstune"
+  if command -v btrfs >/dev/null; then
+    btrfs device scan --forget "$root_part" || true
+  fi
+  btrfstune -f -u "$root_part"
 
   root_mnt=$(mktemp -d)
   mount -o subvol=@ "$root_part" "$root_mnt"
   btrfs filesystem resize max "$root_mnt"
   btrfs filesystem label "$root_mnt" OMARCHYROOT
-  umount "$root_mnt"
-  if command -v btrfs >/dev/null; then
-    btrfs device scan --forget "$root_part" || true
-  fi
-  btrfstune -f -u "$root_part"
-  mount -o subvol=@ "$root_part" "$root_mnt"
   root_uuid=$(blkid -s UUID -o value "$root_part")
   [[ -n $root_uuid ]] || fail "no UUID on $root_part"
 

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -389,11 +389,11 @@ install_into_free_space() {
   [[ -n $choice ]] || fail "cancelled"
   target_name=${choice%% *}
   target_dev=/dev/$target_name
-  region=$(largest_free_region "$target_dev")
+  region=$(largest_free_region "$target_dev") || fail "no free region on $target_dev"
   read -r hole_start hole_size <<<"$region"
-  hole_end=$(( hole_start + hole_size ))
-  # Leave 1MiB at the end of the hole for GPT backup slack on some tools
-  (( hole_end > hole_start + min_mib )) || fail "free region shrank"
+  read -r hole_start hole_size hole_end <<<"$(clamp_free_region "$hole_start" "$hole_size" "$(device_mib "$target_dev")")" \
+    || fail "free region does not fit on $target_dev"
+  (( hole_size >= min_mib )) || fail "free region shrank"
 
   printf '==> selected %s hole %sMiB-%sMiB (%sMiB)\n' \
     "$target_dev" "$hole_start" "$hole_end" "$hole_size"
@@ -434,6 +434,14 @@ install_into_free_space() {
 
   before_apple=$(apple_partition_snapshot "$target_dev")
   before_names=$(partition_names_on "$target_name")
+
+  printf '==> growing GPT to the full device (USB image often smaller than the stick)\n'
+  grow_gpt_to_device "$target_dev"
+  partprobe "$target_dev" 2>/dev/null || true
+  region=$(largest_free_region "$target_dev") || fail "no free region on $target_dev after GPT grow"
+  read -r hole_start hole_size <<<"$region"
+  read -r hole_start hole_size hole_end <<<"$(clamp_free_region "$hole_start" "$hole_size" "$(device_mib "$target_dev")")" \
+    || fail "free region does not fit on $target_dev after GPT grow"
 
   printf '==> mkpart root on %s (%sMiB-%sMiB)\n' "$target_dev" "$hole_start" "$hole_end"
   parted -s "$target_dev" mkpart root btrfs "${hole_start}MiB" "${hole_end}MiB"

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -358,10 +358,10 @@ install_into_free_space() {
   local before_names before_apple backup
   local root_part root_mnt esp_part esp_mnt
   local root_uuid esp_uuid live_esp_mnt live_esp_mounted_by_us
+  local payload_mnt before_efi after_efi before_prot after_prot
   local created_parts=()
 
   command -v parted >/dev/null || fail "parted not found"
-  [[ -f $SHARE/grub-embed-install.cfg ]] || fail "missing $SHARE/grub-embed-install.cfg"
 
   payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
   min_bytes=$(( payload_bytes + 64 * 1024 * 1024 ))
@@ -417,6 +417,14 @@ install_into_free_space() {
   [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
   esp_part=$(existing_esp_on "$target_name" || true)
   [[ -n $esp_part ]] || fail "$target_dev has no ESP; will not create one next to APFS"
+
+  # Do not dd a mounted payload (btrfs csum corruption). Overlay lowerdir stays.
+  if (( running_from_this_live_usb != 1 )); then
+    payload_mnt=$(findmnt -n -o TARGET "$live_partition" || true)
+    if [[ -n $payload_mnt ]]; then
+      umount "$payload_mnt" || fail "could not unmount $payload_mnt before dd"
+    fi
+  fi
 
   backup=$(mktemp /tmp/omarchy-gpt-${target_name}.XXXXXX)
   if command -v sfdisk >/dev/null; then
@@ -481,6 +489,8 @@ EOF
     mount "$esp_part" "$esp_mnt"
     esp_mounted_by_us=1
   fi
+  before_efi=$(sha256sum "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" 2>/dev/null || true)
+  before_prot=$( (cd "$esp_mnt" && find asahi m1n1 vendorfw EFI/asahi -type f 2>/dev/null | sort | xargs -r sha256sum) || true )
 
   live_esp_mnt=$(findmnt -n -o TARGET "$source_esp" || true)
   live_esp_mounted_by_us=0
@@ -491,7 +501,8 @@ EOF
   fi
   [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || fail "no vmlinuz on live ESP"
   [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || fail "no initramfs-linux-asahi.img on live ESP"
-  cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-linux-asahi"
+  # Unique names so a shared System ESP (NVMe /boot) is not overwritten.
+  cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-omarchy-usb-root"
   cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-omarchy-usb-root.img"
   if (( live_esp_mounted_by_us == 1 )); then
     umount "$live_esp_mnt"
@@ -502,7 +513,7 @@ EOF
   cat >"$esp_mnt/grub/custom.cfg" <<EOF
 menuentry 'Omarchy Mac (new root $root_uuid)' {
   search --no-floppy --file /initramfs-omarchy-usb-root.img --set=root
-  linux /vmlinuz-linux-asahi root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
+  linux /vmlinuz-omarchy-usb-root root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
   initrd /initramfs-omarchy-usb-root.img
 }
 EOF
@@ -511,6 +522,11 @@ EOF
     printf '\nif [ -f /grub/custom.cfg ]; then source /grub/custom.cfg; fi\n' \
       >>"$esp_mnt/grub/grub.cfg"
   fi
+
+  after_efi=$(sha256sum "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" 2>/dev/null || true)
+  [[ $before_efi == "$after_efi" ]] || fail "BOOTAA64.EFI changed — aborting"
+  after_prot=$( (cd "$esp_mnt" && find asahi m1n1 vendorfw EFI/asahi -type f 2>/dev/null | sort | xargs -r sha256sum) || true )
+  [[ $before_prot == "$after_prot" ]] || fail "asahi/m1n1/vendorfw on the ESP changed — aborting"
 
   esp_uuid=$(blkid -s UUID -o value "$esp_part")
   printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -53,11 +53,11 @@ booted live USB the same day: 14.5G stick → Lexar; U-Boot skipped
 `switch_root`, systemd userspace, and Wi-Fi association are done
 (2026-08-23). Partition install (ESP + persistent USB root, no overlay) is proven on
 metal (2026-08-24): 14.5G stick, GRUB `Omarchy Mac (USB root)`,
-`omarchy-usb-wait` mounted the new UUID, hostname `omarchy-mac`. Free-space
-install (`parted mkpart` in a hole only, never mklabel, `custom.cfg` on
-the existing ESP) is loopback-tested; this NVMe currently has no hole —
-shrink APFS from macOS, never from Linux. Not yet: LUKS, Omarchy packages,
-or a real internal-disk install.
+`omarchy-usb-wait` mounted the new UUID, hostname `omarchy-mac`. Free-space install is proven on the Lexar hole (2026-08-24): live
+partitions kept, `OMARCHYROOT` 11.4G. Wipe-install 14.5G stick booted
+warm, `root@omarchy-mac`, nmtui Rescan then `ping www.google.com`. This
+NVMe still has no hole — shrink APFS from macOS, never from Linux. Not
+yet: LUKS, Omarchy packages, or a real internal-disk install.
 
 ## Architecture: one rootfs, two front doors
 

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -53,8 +53,11 @@ booted live USB the same day: 14.5G stick → Lexar; U-Boot skipped
 `switch_root`, systemd userspace, and Wi-Fi association are done
 (2026-08-23). Partition install (ESP + persistent USB root, no overlay) is proven on
 metal (2026-08-24): 14.5G stick, GRUB `Omarchy Mac (USB root)`,
-`omarchy-usb-wait` mounted the new UUID, hostname `omarchy-mac`. Not yet:
-LUKS, Omarchy packages, or install onto internal NVMe.
+`omarchy-usb-wait` mounted the new UUID, hostname `omarchy-mac`. Free-space
+install (`parted mkpart` in a hole only, never mklabel, `custom.cfg` on
+the existing ESP) is loopback-tested; this NVMe currently has no hole —
+shrink APFS from macOS, never from Linux. Not yet: LUKS, Omarchy packages,
+or a real internal-disk install.
 
 ## Architecture: one rootfs, two front doors
 

--- a/test/partition
+++ b/test/partition
@@ -51,6 +51,19 @@ check "rollback leaves 4 partitions" "(( $part_count == 4 ))"
 dump_rolled=$(sfdisk --dump "$img")
 check "iBoot type survives rollback" "grep -qi '$APPLE_IBOOT' <<<'$(printf '%s' "$dump_rolled")'"
 
+img_grow=$(mktemp)
+truncate -s 4G "$img_grow"
+parted -s "$img_grow" mklabel gpt mkpart payload 1MiB 100%
+truncate -s 8G "$img_grow"
+grow_gpt_to_device "$img_grow"
+region=$(largest_free_region "$img_grow")
+read -r gs gsz <<<"$region"
+read -r gs gsz ge <<<"$(clamp_free_region "$gs" "$gsz" "$(device_mib "$img_grow")")"
+check "grown image has a hole" "(( $gsz >= 2048 ))"
+parted -s "$img_grow" mkpart root btrfs "${gs}MiB" "${ge}MiB"
+check "mkpart in grown image hole succeeds" "parted -s '$img_grow' print | grep -q root"
+rm -f "$img_grow"
+
 img2=$(mktemp)
 truncate -s 2G "$img2"
 parted -s "$img2" mklabel gpt mkpart full 1MiB 100%

--- a/test/partition
+++ b/test/partition
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Unprivileged GPT tests for free-space install. Uses an image file, not NVMe.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../configs/usb/rootfs/omarchy-mac-disk.sh
+source "${repo_root}/configs/usb/rootfs/omarchy-mac-disk.sh"
+
+failures=0
+check() {
+  local desc=$1
+  shift
+  if bash -c "$*"; then
+    printf 'ok   - %s\n' "$desc"
+  else
+    printf 'FAIL - %s\n' "$desc"
+    failures=$((failures + 1))
+  fi
+}
+
+img=$(mktemp)
+cleanup() { rm -f "$img"; }
+trap cleanup EXIT
+
+truncate -s 8G "$img"
+parted -s "$img" mklabel gpt \
+  mkpart iBoot 1MiB 501MiB \
+  mkpart APFS 501MiB 2501MiB \
+  mkpart ESP 2501MiB 3001MiB \
+  mkpart Recovery 6500MiB 8191MiB
+parted -s "$img" type 1 "$APPLE_IBOOT"
+parted -s "$img" type 2 "$APPLE_APFS"
+parted -s "$img" type 4 "$APPLE_RECOVERY"
+
+region=$(largest_free_region "$img")
+read -r hole_start hole_size <<<"$region"
+check "largest_free_region finds a hole" "[[ -n '$region' ]]"
+check "hole is at least 2GiB" "(( $hole_size >= 2048 ))"
+check "hole starts after ESP" "(( $hole_start >= 3000 ))"
+
+parted -s "$img" mkpart root btrfs "${hole_start}MiB" "$((hole_start + 2000))MiB"
+
+dump_after=$(sfdisk --dump "$img")
+check "iBoot type unchanged" "grep -qi '$APPLE_IBOOT' <<<'$(printf '%s' "$dump_after")'"
+check "APFS type unchanged" "grep -qi '$APPLE_APFS' <<<'$(printf '%s' "$dump_after")'"
+check "Recovery type unchanged" "grep -qi '$APPLE_RECOVERY' <<<'$(printf '%s' "$dump_after")'"
+
+parted -s "$img" rm 5
+part_count=$(parted -s "$img" print | awk '/^[[:space:]]*[1-9]/ { n++ } END { print n+0 }')
+check "rollback leaves 4 partitions" "(( $part_count == 4 ))"
+dump_rolled=$(sfdisk --dump "$img")
+check "iBoot type survives rollback" "grep -qi '$APPLE_IBOOT' <<<'$(printf '%s' "$dump_rolled")'"
+
+img2=$(mktemp)
+truncate -s 2G "$img2"
+parted -s "$img2" mklabel gpt mkpart full 1MiB 100%
+if largest_free_region "$img2" >/dev/null; then
+  printf 'FAIL - no-hole disk should not report a usable region\n'
+  failures=$((failures + 1))
+else
+  printf 'ok   - no-hole disk reports no usable region\n'
+fi
+rm -f "$img2"
+
+if (( failures > 0 )); then
+  echo "${failures} partition test failure(s)"
+  exit 1
+fi
+echo "partition tests passed"

--- a/test/unit
+++ b/test/unit
@@ -65,7 +65,7 @@ check "rootfs pacstraps mesa and gum" grep -q ' mesa ' \
 check "hid_apple fnmode=1 is in the tree" grep -q 'fnmode=1' \
   "${repo_root}/configs/usb/modprobe.d/hid_apple.conf"
 check "install script refuses Apple partition GUIDs" grep -q 7c3457ef \
-  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-disk.sh"
 check "install script copies through last partition not whole disk" grep -q iflag=count_bytes \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install script unmounts the live USB before dd" grep -q 'unmount_disk "$source_dev"' \
@@ -74,8 +74,15 @@ check "install script keeps overlay lowerdir mounted" grep -q omarchy-mac-overla
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install script rewrites clone btrfs UUID" grep -q 'btrfstune -f -u' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
-check "install script offers persistent root install" grep -q 'Install to a disk' \
+check "install script offers persistent root install" grep -q 'Install to a blank USB' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install script offers free-space install" grep -q 'Install into free space' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "free-space install does not wipefs" \
+  bash -c 'awk "/^install_into_free_space\\(\\)/,/^action=/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -qv wipefs'
+check "sh -n omarchy-mac-disk.sh" bash -n \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-disk.sh"
+check "partition loopback tests" "${repo_root}/test/partition"
 check "install script labels the installed root OMARCHYROOT" grep -q OMARCHYROOT \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "sh -n omarchy-mac-install" bash -n \

--- a/test/unit
+++ b/test/unit
@@ -109,6 +109,10 @@ check "install copies initramfs from live ESP" grep -q 'initramfs-linux-asahi.im
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install initrd name is unique vs NVMe" grep -q initramfs-omarchy-usb-root.img \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "free-space install uses unique vmlinuz on shared ESP" grep -q vmlinuz-omarchy-usb-root \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "free-space install refuses to change BOOTAA64.EFI" grep -q 'BOOTAA64.EFI changed' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 


### PR DESCRIPTION
## Summary

Adds **Install into free space**: `parted mkpart` in an existing GPT hole only. No `mklabel`, no `wipefs`. Apple iBoot/APFS/Recovery types are snapshotted and the install aborts if they change. The existing ESP gets `grub/custom.cfg` only — it does not replace `BOOTAA64.EFI`.

`--dry-run` lists usable holes. This machine's NVMe has none until APFS is shrunk **from macOS**, never from Linux. The Lexar live USB currently has ~11GiB unused after the payload (safe metal target; restorable from the live image).

Loopback-tested (`test/partition`). Wipe-USB and clone paths are unchanged.