### PR TITLE
Fix NVMe free-space alignment and Apple GPT snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,11 @@ GUIDs):
   (that file is the NVMe LUKS initramfs).
 - **Install into free space** — `parted mkpart` in an existing GPT hole only.
   Never `mklabel`/`wipefs`. Proven on the Lexar hole (keep live
-  `OMARCHYISO`/`OMARCHYLIVE`, new `OMARCHYROOT` 11.4G). NVMe still has no
-  hole until APFS is shrunk **from macOS**. Writes `grub/custom.cfg` on the
+  `OMARCHYISO`/`OMARCHYLIVE`, new `OMARCHYROOT` 11.4G) and on this NVMe
+  after shrinking APFS **from macOS** (2026-08-24): p7 46G,
+  `root@omarchy-mac`, existing Omarchy still the default GRUB entry.
+  Parted whole-MiB starts can sit inside APFS on 4K NVMe — mkpart insets
+  1MiB. Apple GPT snapshots use `lsblk -l` so tree glyphs do not abort
+  after the new partition appears. Writes `grub/custom.cfg` on the
   existing ESP; unique `vmlinuz-omarchy-usb-root` / initrd names; does not
   replace `BOOTAA64.EFI`.

--- a/configs/usb/rootfs/omarchy-mac-disk.sh
+++ b/configs/usb/rootfs/omarchy-mac-disk.sh
@@ -91,6 +91,17 @@ grow_gpt_to_device() {
   fi
 }
 
+# Parted reports free-space start in whole MiB, which can land inside
+# the previous partition's last fractional MiB (Apple NVMe 4K). Step 1MiB
+# in from both ends.
+inset_free_region() {
+  local start=$1 size=$2
+  start=$(( start + 1 ))
+  size=$(( size - 2 ))
+  (( size >= MIN_FREE_MIB )) || return 1
+  printf '%s %s\n' "$start" "$size"
+}
+
 # start size -> start size end, clamped so parted does not treat the
 # exact device size as "outside of the device".
 clamp_free_region() {

--- a/configs/usb/rootfs/omarchy-mac-disk.sh
+++ b/configs/usb/rootfs/omarchy-mac-disk.sh
@@ -117,6 +117,7 @@ clamp_free_region() {
 }
 
 # Existing System ESP: GPT ESP type, or FAT labelled EFI*.
+# lsblk -l so tree glyphs are not part of NAME.
 existing_esp_on() {
   local disk=$1 name type label
   while read -r name type label; do
@@ -130,7 +131,7 @@ existing_esp_on() {
       printf '/dev/%s\n' "$name"
       return 0
     fi
-  done < <(lsblk -n -o NAME,PARTTYPE,LABEL "/dev/$disk" 2>/dev/null)
+  done < <(lsblk -ln -o NAME,PARTTYPE,LABEL "/dev/$disk" 2>/dev/null)
   return 1
 }
 

--- a/configs/usb/rootfs/omarchy-mac-disk.sh
+++ b/configs/usb/rootfs/omarchy-mac-disk.sh
@@ -16,11 +16,12 @@ disk_has_apple_partitions() {
     [[ -z $type ]] && continue
     type=${type,,}
     [[ $type == "$APPLE_APFS" || $type == "$APPLE_IBOOT" || $type == "$APPLE_RECOVERY" ]] && return 0
-  done < <(lsblk -n -o PARTTYPE "/dev/$disk" 2>/dev/null)
+  done < <(lsblk -ln -o PARTTYPE "/dev/$disk" 2>/dev/null)
   return 1
 }
 
 # Snapshot "name type" lines for Apple partitions on $1 (path or NAME).
+# Use -l so tree glyphs (├/└) do not change when a new partition is added.
 apple_partition_snapshot() {
   local dev=$1 name type
   while read -r name type; do
@@ -29,7 +30,7 @@ apple_partition_snapshot() {
     if [[ $type == "$APPLE_APFS" || $type == "$APPLE_IBOOT" || $type == "$APPLE_RECOVERY" ]]; then
       printf '%s %s\n' "$name" "$type"
     fi
-  done < <(lsblk -n -o NAME,PARTTYPE "$dev" 2>/dev/null)
+  done < <(lsblk -ln -o NAME,PARTTYPE "$dev" 2>/dev/null)
 }
 
 # Print "start_mib size_mib" for each Free Space region on a parted device

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -391,6 +391,8 @@ install_into_free_space() {
   target_dev=/dev/$target_name
   region=$(largest_free_region "$target_dev") || fail "no free region on $target_dev"
   read -r hole_start hole_size <<<"$region"
+  read -r hole_start hole_size <<<"$(inset_free_region "$hole_start" "$hole_size")" \
+    || fail "free region too small after alignment inset"
   read -r hole_start hole_size hole_end <<<"$(clamp_free_region "$hole_start" "$hole_size" "$(device_mib "$target_dev")")" \
     || fail "free region does not fit on $target_dev"
   (( hole_size >= min_mib )) || fail "free region shrank"
@@ -435,16 +437,20 @@ install_into_free_space() {
   before_apple=$(apple_partition_snapshot "$target_dev")
   before_names=$(partition_names_on "$target_name")
 
-  printf '==> growing GPT to the full device (USB image often smaller than the stick)\n'
-  grow_gpt_to_device "$target_dev"
-  partprobe "$target_dev" 2>/dev/null || true
+  if ! disk_is_nvme "$target_name" && ! disk_has_apple_partitions "$target_name"; then
+    printf '==> growing GPT to the full device (USB image often smaller than the stick)\n'
+    grow_gpt_to_device "$target_dev"
+    partprobe "$target_dev" 2>/dev/null || true
+  fi
   region=$(largest_free_region "$target_dev") || fail "no free region on $target_dev after GPT grow"
   read -r hole_start hole_size <<<"$region"
+  read -r hole_start hole_size <<<"$(inset_free_region "$hole_start" "$hole_size")" \
+    || fail "free region too small after alignment inset"
   read -r hole_start hole_size hole_end <<<"$(clamp_free_region "$hole_start" "$hole_size" "$(device_mib "$target_dev")")" \
     || fail "free region does not fit on $target_dev after GPT grow"
 
   printf '==> mkpart root on %s (%sMiB-%sMiB)\n' "$target_dev" "$hole_start" "$hole_end"
-  parted -s "$target_dev" mkpart root btrfs "${hole_start}MiB" "${hole_end}MiB"
+  parted -s -a optimal "$target_dev" mkpart root btrfs "${hole_start}MiB" "${hole_end}MiB"
   partprobe "$target_dev" 2>/dev/null || true
   command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
   sleep 1

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -55,9 +55,10 @@ booted live USB the same day: 14.5G stick → Lexar; U-Boot skipped
 metal (2026-08-24): 14.5G stick, GRUB `Omarchy Mac (USB root)`,
 `omarchy-usb-wait` mounted the new UUID, hostname `omarchy-mac`. Free-space install is proven on the Lexar hole (2026-08-24): live
 partitions kept, `OMARCHYROOT` 11.4G. Wipe-install 14.5G stick booted
-warm, `root@omarchy-mac`, nmtui Rescan then `ping www.google.com`. This
-NVMe still has no hole — shrink APFS from macOS, never from Linux. Not
-yet: LUKS, Omarchy packages, or a real internal-disk install.
+warm, `root@omarchy-mac`, nmtui Rescan then `ping www.google.com`. NVMe
+hole after macOS APFS shrink (2026-08-24): p7 46G, existing Omarchy still
+boots, new GRUB entry `root@omarchy-mac`. Shrink APFS from macOS, never
+from Linux. Not yet: LUKS or Omarchy packages on the new root.
 
 ## Architecture: one rootfs, two front doors
 
@@ -356,8 +357,9 @@ GitHub Releases vs R2 vs split assets.
 ### S7 — Testing
 
 - `test/unit` — partitioning against loopback files; installer logic.
-- Hardware, non-destructive: install to an external disk, not internal NVMe.
-  This machine's internal GPT has **zero** free space.
+- Hardware, non-destructive: USB first; internal NVMe only into a hole
+  left by shrinking APFS **from macOS**. This machine's p7 is that hole
+  (2026-08-24).
 - No Apple SoC QEMU. `cidata` plus `test/acceptance.d` after first boot.
 
 ## Verification

--- a/test/partition
+++ b/test/partition
@@ -37,6 +37,8 @@ read -r hole_start hole_size <<<"$region"
 check "largest_free_region finds a hole" "[[ -n '$region' ]]"
 check "hole is at least 2GiB" "(( $hole_size >= 2048 ))"
 check "hole starts after ESP" "(( $hole_start >= 3000 ))"
+read -r inset_start inset_size <<<"$(inset_free_region "$hole_start" "$hole_size")"
+check "inset steps 1MiB into the hole" "(( $inset_start == $hole_start + 1 && $inset_size == $hole_size - 2 ))"
 
 parted -s "$img" mkpart root btrfs "${hole_start}MiB" "$((hole_start + 2000))MiB"
 
@@ -58,6 +60,7 @@ truncate -s 8G "$img_grow"
 grow_gpt_to_device "$img_grow"
 region=$(largest_free_region "$img_grow")
 read -r gs gsz <<<"$region"
+read -r gs gsz <<<"$(inset_free_region "$gs" "$gsz")"
 read -r gs gsz ge <<<"$(clamp_free_region "$gs" "$gsz" "$(device_mib "$img_grow")")"
 check "grown image has a hole" "(( $gsz >= 2048 ))"
 parted -s "$img_grow" mkpart root btrfs "${gs}MiB" "${ge}MiB"


### PR DESCRIPTION
## Summary

Free-space install now survives a real NVMe hole (APFS shrunk from macOS, never from Linux). Two installer bugs blocked a clean `mkpart`: parted's whole-MiB start can sit inside the previous APFS partition on 4K NVMe, and the Apple-GUID snapshot aborted because `lsblk` tree glyphs changed when p7 appeared.

Insets the hole 1MiB, snapshots with `lsblk -l`, and does not `sgdisk -e` on NVMe. Metal on this M2 Max: p7 46G, existing Omarchy still the default GRUB entry, new entry reached `root@omarchy-mac`. `test/partition` covers the inset.