### PR TITLE
Own System ESP GRUB after UEFI-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ is not defined. Live GRUB prints `OMARCHY USB GRUB`; installed GRUB prints
 `OMARCHY USB INSTALL` / menu `Omarchy Mac (USB root)`. Omarchy Linux /
 Advanced options means you are on NVMe.
 
+Hiding NVMe `EFI/BOOT/BOOTAA64.EFI` (rename to `.omarchy-bak`; m1n1 stays)
+makes U-Boot take USB GRUB — proven 2026-08-24 after `usb reset` (Type-C
+still needs that). Restore from macOS if Linux will not boot: Apple picker
+(hold power) → macOS. `diskutil mount "EFI - OMARC"` can fail even when
+the volume is fine; then:
+
+```
+sudo mkdir -p /Volumes/esp
+sudo mount -t msdos /dev/disk0s4 /Volumes/esp
+mv /Volumes/esp/EFI/BOOT/BOOTAA64.EFI.omarchy-bak \
+   /Volumes/esp/EFI/BOOT/BOOTAA64.EFI
+sudo umount /Volumes/esp
+```
+
+Copy the pancake `BOOTAA64.EFI`, not the Lexar's `EFI/BOOT/` file (that is
+USB GRUB). A spare copy lives on the live ESP as `omarchy-restore/`.
+
 Wi-Fi: nmtui Rescan until SSIDs appear (a few rescans is normal), then
 Activate. On the persistent USB root (2026-08-24) that was enough for
 `ping www.google.com`; nmcli is optional.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ GUIDs):
   `root@omarchy-mac`, existing Omarchy still the default GRUB entry.
   Parted whole-MiB starts can sit inside APFS on 4K NVMe — mkpart insets
   1MiB. Apple GPT snapshots use `lsblk -l` so tree glyphs do not abort
-  after the new partition appears. Writes `grub/custom.cfg` on the
-  existing ESP; unique `vmlinuz-omarchy-usb-root` / initrd names; does not
-  replace `BOOTAA64.EFI`.
+  after the new partition appears. Two System ESP modes: **piggyback** if
+  `BOOTAA64.EFI` already exists (`custom.cfg` only, file unchanged);
+  **own** if the ESP is UEFI-only (no GRUB) — same `grub-mkstandalone`
+  recipe as wipe-USB, marker `/omarchy-mac-root`, never `mkfs` or
+  `update-m1n1`. Unique `vmlinuz-omarchy-usb-root` / initrd names.
+  `m1n1/` / `vendorfw/` / `asahi/` hashes must match after. A fourth
+  menu item writes GRUB for an existing `OMARCHYROOT` without `mkpart`.

--- a/README.md
+++ b/README.md
@@ -172,3 +172,8 @@ GUIDs):
   `update-m1n1`. Unique `vmlinuz-omarchy-usb-root` / initrd names.
   `m1n1/` / `vendorfw/` / `asahi/` hashes must match after. A fourth
   menu item writes GRUB for an existing `OMARCHYROOT` without `mkpart`.
+  **Own-mode metal 2026-08-25:** hid NVMe GRUB, rebuilt live USB, free-space
+  `mkpart` p7, wrote `BOOTAA64.EFI`, USB unplugged → `root@omarchy-mac`.
+  U-Boot only loads one `BOOTAA64.EFI`; own-mode replaces an existing
+  Omarchy GRUB. Restore pancake with the original file (not the live USB's)
+  then `grub-mkconfig` so `quiet splash` brings the branded Plymouth unlock.

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -82,6 +82,8 @@ install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" \
   "$mnt/usr/local/share/omarchy-mac-iso/omarchy-mac-disk.sh"
 install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" \
   "$mnt/usr/local/sbin/omarchy-mac-disk.sh"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-esp.sh" \
+  "$mnt/usr/local/share/omarchy-mac-iso/omarchy-mac-esp.sh"
 install -d "$mnt/usr/local/share/omarchy-mac-iso/initcpio/hooks"
 install -d "$mnt/usr/local/share/omarchy-mac-iso/initcpio/install"
 install -m644 "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" \
@@ -90,6 +92,8 @@ install -m644 "$repo_root/configs/usb/grub-embed.cfg" \
   "$mnt/usr/local/share/omarchy-mac-iso/grub-embed.cfg"
 install -m644 "$repo_root/configs/usb/grub-embed-install.cfg" \
   "$mnt/usr/local/share/omarchy-mac-iso/grub-embed-install.cfg"
+install -m644 "$repo_root/configs/usb/grub-embed-system.cfg" \
+  "$mnt/usr/local/share/omarchy-mac-iso/grub-embed-system.cfg"
 install -m644 "$repo_root/configs/usb-initcpio/hooks/omarchy-usb-wait" \
   "$mnt/usr/local/share/omarchy-mac-iso/initcpio/hooks/omarchy-usb-wait"
 install -m644 "$repo_root/configs/usb-initcpio/install/omarchy-usb-wait" \

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -76,6 +76,7 @@ cp -a "/usr/lib/modules/$kver" "$mnt/usr/lib/modules/"
 install -m644 "$repo_root/configs/usb/rootfs/issue" "$mnt/etc/issue"
 install -d "$mnt/etc/systemd/system"
 install -d "$mnt/usr/local/sbin"
+install -d "$mnt/usr/local/share/omarchy-mac-iso"
 install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-install" \
   "$mnt/usr/local/sbin/omarchy-mac-install"
 install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" \

--- a/configs/usb/grub-embed-system.cfg
+++ b/configs/usb/grub-embed-system.cfg
@@ -1,0 +1,6 @@
+# Embedded in System ESP BOOTAA64.EFI after a UEFI-only install.
+# Must not match the live USB (/omarchy-usb-live) or a wipe-USB
+# install (/omarchy-usb-install). Search a file we only place on
+# the internal ESP when we own GRUB.
+search --no-floppy --file /omarchy-mac-root --set=root
+configfile /grub/grub.cfg

--- a/configs/usb/rootfs/omarchy-mac-esp.sh
+++ b/configs/usb/rootfs/omarchy-mac-esp.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# System ESP GRUB helpers. Safe to source from tests.
+# Never write m1n1/, vendorfw/, or asahi/. Never mkfs.vfat the ESP.
+
+esp_has_bootloader() {
+  local esp_mnt=$1
+  [[ -f $esp_mnt/EFI/BOOT/BOOTAA64.EFI ]]
+}
+
+esp_protected_hashes() {
+  local esp_mnt=$1
+  (cd "$esp_mnt" && find asahi m1n1 vendorfw EFI/asahi -type f 2>/dev/null | sort | xargs -r sha256sum) || true
+}
+
+esp_copy_unique_kernels() {
+  local live_esp_mnt=$1 esp_mnt=$2
+  [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || return 1
+  [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || return 1
+  cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-omarchy-usb-root"
+  cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-omarchy-usb-root.img"
+}
+
+# Piggyback on an OS that already owns BOOTAA64.EFI (custom.cfg only).
+write_piggyback_esp_grub() {
+  local esp_mnt=$1 root_uuid=$2
+  mkdir -p "$esp_mnt/grub"
+  cat >"$esp_mnt/grub/custom.cfg" <<EOF
+menuentry 'Omarchy Mac (new root $root_uuid)' {
+  search --no-floppy --file /initramfs-omarchy-usb-root.img --set=root
+  linux /vmlinuz-omarchy-usb-root root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
+  initrd /initramfs-omarchy-usb-root.img
+}
+EOF
+  if [[ -f $esp_mnt/grub/grub.cfg ]] && ! grep -q custom.cfg "$esp_mnt/grub/grub.cfg"; then
+    printf '\nif [ -f /grub/custom.cfg ]; then source /grub/custom.cfg; fi\n' \
+      >>"$esp_mnt/grub/grub.cfg"
+  fi
+}
+
+# Take over a UEFI-only System ESP: write BOOTAA64.EFI next to m1n1.
+# $3 is grub-embed-system.cfg. Does not touch m1n1/vendorfw/asahi.
+write_owned_esp_grub() {
+  local esp_mnt=$1 root_uuid=$2 embed_cfg=$3
+  [[ -f $embed_cfg ]] || return 1
+  command -v grub-mkstandalone >/dev/null || return 1
+  mkdir -p "$esp_mnt/EFI/BOOT" "$esp_mnt/grub"
+  : >"$esp_mnt/omarchy-mac-root"
+  cat >"$esp_mnt/grub/grub.cfg" <<EOF
+echo '========================================'
+echo '  OMARCHY MAC (System ESP, not USB)'
+echo '========================================'
+set timeout=8
+set default=0
+
+search --no-floppy --file /omarchy-mac-root --set=root
+
+menuentry 'Omarchy Mac' {
+  linux /vmlinuz-omarchy-usb-root root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
+  initrd /initramfs-omarchy-usb-root.img
+}
+EOF
+  cp "$esp_mnt/grub/grub.cfg" "$esp_mnt/EFI/BOOT/grub.cfg"
+  grub-mkstandalone -O arm64-efi \
+    --fonts="" --locales="" --themes="" \
+    --install-modules="linux fat ext2 btrfs part_gpt search search_label search_fs_uuid search_fs_file echo normal configfile gzio reboot sleep" \
+    --modules="part_gpt fat search search_fs_file configfile linux echo normal" \
+    -o "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" \
+    "boot/grub/grub.cfg=$embed_cfg" >/dev/null
+}
+
+# Print /dev/NAME of btrfs labelled OMARCHYROOT on $1 (disk NAME).
+existing_omarchy_root_on() {
+  local disk=$1 name fstype label
+  while read -r name fstype label; do
+    [[ $name == "$disk" ]] && continue
+    [[ $fstype == btrfs && $label == OMARCHYROOT ]] || continue
+    printf '/dev/%s\n' "$name"
+    return 0
+  done < <(lsblk -ln -o NAME,FSTYPE,LABEL "/dev/$disk" 2>/dev/null)
+  return 1
+}

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -19,6 +19,15 @@ elif [[ -f $here/omarchy-mac-disk.sh ]]; then
 else
   fail "omarchy-mac-disk.sh not found"
 fi
+if [[ -f $SHARE/omarchy-mac-esp.sh ]]; then
+  # shellcheck source=/dev/null
+  source "$SHARE/omarchy-mac-esp.sh"
+elif [[ -f $here/omarchy-mac-esp.sh ]]; then
+  # shellcheck source=/dev/null
+  source "$here/omarchy-mac-esp.sh"
+else
+  fail "omarchy-mac-esp.sh not found"
+fi
 
 [[ $EUID == 0 ]] || fail "run as root"
 command -v gum >/dev/null || fail "gum not found"
@@ -352,13 +361,74 @@ EOF
   lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
 }
 
+# Copy unique kernels from the live ESP, then piggyback (existing GRUB)
+# or own (UEFI-only: write BOOTAA64.EFI). Never touches m1n1/vendorfw/asahi.
+# Prints "piggyback" or "own" to stdout. Caller holds the root mount.
+apply_system_esp_bootloader() {
+  local esp_part=$1 root_uuid=$2 source_esp=$3
+  local esp_mnt live_esp_mnt
+  local esp_mounted_by_us=0 live_esp_mounted_by_us=0
+  local before_efi after_efi before_prot after_prot
+  local embed_cfg mode
+
+  embed_cfg=$SHARE/grub-embed-system.cfg
+  [[ -f $embed_cfg ]] || embed_cfg=$here/../grub-embed-system.cfg
+  [[ -f $embed_cfg ]] || fail "missing grub-embed-system.cfg — rebuild the live USB"
+
+  esp_mnt=$(findmnt -n -o TARGET "$esp_part" || true)
+  if [[ -z $esp_mnt ]]; then
+    esp_mnt=$(mktemp -d)
+    mount "$esp_part" "$esp_mnt" >/dev/null
+    esp_mounted_by_us=1
+  fi
+  before_prot=$(esp_protected_hashes "$esp_mnt")
+  before_efi=$(sha256sum "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" 2>/dev/null || true)
+
+  live_esp_mnt=$(findmnt -n -o TARGET "$source_esp" || true)
+  if [[ -z $live_esp_mnt ]]; then
+    live_esp_mnt=$(mktemp -d)
+    mount -o ro "$source_esp" "$live_esp_mnt" >/dev/null
+    live_esp_mounted_by_us=1
+  fi
+  esp_copy_unique_kernels "$live_esp_mnt" "$esp_mnt" \
+    || fail "no vmlinuz/initramfs on live ESP $source_esp"
+  if (( live_esp_mounted_by_us == 1 )); then
+    umount "$live_esp_mnt"
+    rmdir "$live_esp_mnt"
+  fi
+
+  if esp_has_bootloader "$esp_mnt"; then
+    write_piggyback_esp_grub "$esp_mnt" "$root_uuid"
+    after_efi=$(sha256sum "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" 2>/dev/null || true)
+    [[ $before_efi == "$after_efi" ]] || fail "BOOTAA64.EFI changed — aborting"
+    mode=piggyback
+  else
+    command -v grub-mkstandalone >/dev/null \
+      || fail "grub-mkstandalone not found — rebuild with --usb --rootfs (grub)"
+    write_owned_esp_grub "$esp_mnt" "$root_uuid" "$embed_cfg" \
+      || fail "could not write System ESP GRUB"
+    [[ -f $esp_mnt/EFI/BOOT/BOOTAA64.EFI ]] || fail "BOOTAA64.EFI missing after own-mode write"
+    [[ -f $esp_mnt/omarchy-mac-root ]] || fail "omarchy-mac-root marker missing"
+    mode=own
+  fi
+
+  after_prot=$(esp_protected_hashes "$esp_mnt")
+  [[ $before_prot == "$after_prot" ]] || fail "asahi/m1n1/vendorfw on the ESP changed — aborting"
+
+  if (( esp_mounted_by_us == 1 )); then
+    umount "$esp_mnt"
+    rmdir "$esp_mnt"
+  fi
+  printf '%s\n' "$mode"
+}
+
 install_into_free_space() {
   local payload_bytes min_bytes name size model tran bytes
   local hole_start hole_size hole_end
   local before_names before_apple backup
-  local root_part root_mnt esp_part esp_mnt
-  local root_uuid esp_uuid live_esp_mnt live_esp_mounted_by_us
-  local payload_mnt before_efi after_efi before_prot after_prot
+  local root_part root_mnt esp_part
+  local root_uuid esp_uuid
+  local payload_mnt esp_mode
   local created_parts=()
 
   command -v parted >/dev/null || fail "parted not found"
@@ -504,78 +574,86 @@ EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
 
-  esp_mnt=$(findmnt -n -o TARGET "$esp_part" || true)
-  esp_mounted_by_us=0
-  if [[ -z $esp_mnt ]]; then
-    esp_mnt=$(mktemp -d)
-    mount "$esp_part" "$esp_mnt"
-    esp_mounted_by_us=1
-  fi
-  before_efi=$(sha256sum "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" 2>/dev/null || true)
-  before_prot=$( (cd "$esp_mnt" && find asahi m1n1 vendorfw EFI/asahi -type f 2>/dev/null | sort | xargs -r sha256sum) || true )
-
-  live_esp_mnt=$(findmnt -n -o TARGET "$source_esp" || true)
-  live_esp_mounted_by_us=0
-  if [[ -z $live_esp_mnt ]]; then
-    live_esp_mnt=$(mktemp -d)
-    mount -o ro "$source_esp" "$live_esp_mnt"
-    live_esp_mounted_by_us=1
-  fi
-  [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || fail "no vmlinuz on live ESP"
-  [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || fail "no initramfs-linux-asahi.img on live ESP"
-  # Unique names so a shared System ESP (NVMe /boot) is not overwritten.
-  cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-omarchy-usb-root"
-  cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-omarchy-usb-root.img"
-  if (( live_esp_mounted_by_us == 1 )); then
-    umount "$live_esp_mnt"
-    rmdir "$live_esp_mnt"
-  fi
-
-  mkdir -p "$esp_mnt/grub"
-  cat >"$esp_mnt/grub/custom.cfg" <<EOF
-menuentry 'Omarchy Mac (new root $root_uuid)' {
-  search --no-floppy --file /initramfs-omarchy-usb-root.img --set=root
-  linux /vmlinuz-omarchy-usb-root root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
-  initrd /initramfs-omarchy-usb-root.img
-}
-EOF
-  # Standalone USB GRUB sources this from /grub/grub.cfg.
-  if [[ -f $esp_mnt/grub/grub.cfg ]] && ! grep -q custom.cfg "$esp_mnt/grub/grub.cfg"; then
-    printf '\nif [ -f /grub/custom.cfg ]; then source /grub/custom.cfg; fi\n' \
-      >>"$esp_mnt/grub/grub.cfg"
-  fi
-
-  after_efi=$(sha256sum "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" 2>/dev/null || true)
-  [[ $before_efi == "$after_efi" ]] || fail "BOOTAA64.EFI changed — aborting"
-  after_prot=$( (cd "$esp_mnt" && find asahi m1n1 vendorfw EFI/asahi -type f 2>/dev/null | sort | xargs -r sha256sum) || true )
-  [[ $before_prot == "$after_prot" ]] || fail "asahi/m1n1/vendorfw on the ESP changed — aborting"
+  esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp")
 
   esp_uuid=$(blkid -s UUID -o value "$esp_part")
   printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"
 
   sync
   umount "$root_mnt"
-  if (( esp_mounted_by_us == 1 )); then
-    umount "$esp_mnt"
-    rmdir "$esp_mnt"
-  fi
   rmdir "$root_mnt" 2>/dev/null || true
 
   printf '==> done. Did not mklabel %s. New root %s UUID=%s\n' \
     "$target_dev" "$root_part" "$root_uuid"
-  printf '    Boot via existing ESP %s (custom.cfg). GPT dump: %s\n' \
-    "$esp_part" "$backup"
+  if [[ $esp_mode == own ]]; then
+    printf '    System ESP %s: wrote BOOTAA64.EFI (m1n1/vendorfw/asahi unchanged). GPT dump: %s\n' \
+      "$esp_part" "$backup"
+  else
+    printf '    Boot via existing ESP %s (custom.cfg). GPT dump: %s\n' \
+      "$esp_part" "$backup"
+  fi
+  lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
+}
+
+# Re-use an OMARCHYROOT already on the disk. Writes GRUB only: no mkpart, no dd.
+install_grub_for_existing_root() {
+  local name model extra
+  local candidates=()
+  local source_esp esp_part root_part root_uuid
+  local esp_mode
+
+  source_esp=$(esp_partition_on "$live_disk" || true)
+  [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
+
+  while read -r name model; do
+    [[ $name == "$live_disk" ]] && continue
+    existing_esp_on "$name" >/dev/null || continue
+    existing_omarchy_root_on "$name" >/dev/null || continue
+    extra=""
+    disk_has_apple_partitions "$name" && extra=" (keeps APFS)"
+    disk_is_nvme "$name" && extra="${extra} nvme"
+    candidates+=("$name  OMARCHYROOT on ${model:-disk}${extra}")
+  done < <(lsblk -dn -o NAME,MODEL)
+
+  (( ${#candidates[@]} > 0 )) || fail "no disk has both an ESP and an OMARCHYROOT (install into free space first)"
+
+  choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Write GRUB for which existing OMARCHYROOT?")
+  [[ -n $choice ]] || fail "cancelled"
+  target_name=${choice%% *}
+  target_dev=/dev/$target_name
+  esp_part=$(existing_esp_on "$target_name") || fail "$target_dev has no ESP"
+  root_part=$(existing_omarchy_root_on "$target_name") || fail "$target_dev has no OMARCHYROOT"
+  root_uuid=$(blkid -s UUID -o value "$root_part")
+  [[ -n $root_uuid ]] || fail "no UUID on $root_part"
+
+  printf '==> confirm (arrow keys, then enter)\n'
+  gum confirm \
+    "Write GRUB on $esp_part for $root_part (UUID=$root_uuid). No new partition, no mklabel, no LUKS. If the ESP has no BOOTAA64.EFI this will create one. m1n1/vendorfw/asahi stay." \
+    || fail "cancelled"
+
+  if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
+    printf 'dry-run: apply_system_esp_bootloader %s root=%s (own if no BOOTAA64.EFI, else piggyback)\n' \
+      "$esp_part" "$root_uuid"
+    printf 'dry-run: would NOT mklabel, mkpart, or dd\n'
+    return 0
+  fi
+
+  esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp")
+  printf '==> done. GRUB mode=%s ESP=%s root=%s UUID=%s\n' \
+    "$esp_mode" "$esp_part" "$root_part" "$root_uuid"
   lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
 }
 
 action=$(gum choose --header "Omarchy Mac live USB" \
   "Install into free space (keeps existing partitions)" \
+  "Install GRUB for an existing OMARCHYROOT (no new partition)" \
   "Install to a blank USB (wipes the whole disk)" \
   "Clone this live USB onto another stick")
 [[ -n $action ]] || fail "cancelled"
 
 case $action in
   "Install into free space"*) install_into_free_space ;;
+  "Install GRUB for an existing"*) install_grub_for_existing_root ;;
   "Install to a blank USB"*) install_persistent_root ;;
   Clone*) clone_live_usb ;;
   *) fail "unknown action" ;;

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -400,10 +400,14 @@ GitHub Releases vs R2 vs split assets.
    ESP tarball on LINUXBAK; hid NVMe `BOOTAA64.EFI`; USB GRUB appeared
    after `usb reset` (not a no-key autoboot). macOS restore: `diskutil
    mount "EFI - OMARC"` failed; `mount -t msdos /dev/disk0s4 /Volumes/esp`
-   then rename `.omarchy-bak` back. **Rung 2 open:** rebuild live USB with
-   own-mode installer, write GRUB for p7, cold boot with USB unplugged.
-   Do not re-run Asahi's installer. U-Boot is Asahi (`m1n1/boot.bin`), not
-   stock Mac firmware.
+   then rename `.omarchy-bak` back. **Rung 2 done 2026-08-25:** rebuilt
+   live USB (`--usb --rootfs`, SHARE mkdir), hid NVMe GRUB, free-space
+   install `mkpart` p7 (UUID `2bd9f673-…`), wrote System ESP
+   `BOOTAA64.EFI` (`m1n1`/`vendorfw`/`asahi` unchanged), USB unplugged →
+   `root@omarchy-mac`. Own-mode replaces pancake GRUB (one `BOOTAA64.EFI`).
+   Restoring the original file plus `grub-mkconfig` (`quiet splash`) is
+   how this desktop and branded Plymouth come back. Do not re-run Asahi's
+   installer. U-Boot is Asahi (`m1n1/boot.bin`), not stock Mac firmware.
 6. CI green on `workflow_dispatch` before nightly.
 
 ## Coordination

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -135,6 +135,11 @@ Hard constraints, as refusals not comments:
   re-run the Asahi installer to "start over". Hide or replace `BOOTAA64.EFI`
   only after an ESP tarball is off-disk. Wiping the Omarchy LUKS root (p5)
   does not test this — m1n1 lives on p4. p5 and p7 are not adjacent.
+- macOS `diskutil mount "EFI - OMARC"` can refuse a healthy FAT ESP
+  (`failed to mount`). Use `mount -t msdos /dev/disk0s4 /Volumes/esp`
+  (confirm the slice with `diskutil list`; ~500MB FAT). Rename
+  `EFI/BOOT/BOOTAA64.EFI.omarchy-bak` → `BOOTAA64.EFI`. Do not copy the
+  live USB's `EFI/BOOT/BOOTAA64.EFI` onto the System ESP.
 - Never create a second ESP on the USB-after-UEFI-only path. The os-package
   path creates the one System ESP via asahi-installer; that is a different
   front door.
@@ -391,11 +396,14 @@ GitHub Releases vs R2 vs split assets.
    `omarchy snapshot restore` sees `@factory`.
 4. Internal ESP `m1n1/boot.bin`, `vendorfw/`, `asahi/` byte-identical before
    and after.
-5. System ESP GRUB own-mode, metal ladder: (1) ESP tarball off-disk, hide
-   `BOOTAA64.EFI`, USB autoboot without interrupting U-Boot; (2) installer
-   own-mode writes GRUB for p7, cold boot with USB unplugged. macOS stays.
-   Do not re-run Asahi's installer. Timed against the current 8.5 + 14
-   minute path once the desktop payload exists.
+5. System ESP GRUB own-mode, metal ladder. **Rung 1 done 2026-08-24:**
+   ESP tarball on LINUXBAK; hid NVMe `BOOTAA64.EFI`; USB GRUB appeared
+   after `usb reset` (not a no-key autoboot). macOS restore: `diskutil
+   mount "EFI - OMARC"` failed; `mount -t msdos /dev/disk0s4 /Volumes/esp`
+   then rename `.omarchy-bak` back. **Rung 2 open:** rebuild live USB with
+   own-mode installer, write GRUB for p7, cold boot with USB unplugged.
+   Do not re-run Asahi's installer. U-Boot is Asahi (`m1n1/boot.bin`), not
+   stock Mac firmware.
 6. CI green on `workflow_dispatch` before nightly.
 
 ## Coordination

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -115,7 +115,7 @@ pick target free space → parted (read back the slot, never guess) →
 optional fresh luksFormat → dd root.img → btrfs resize max →
 btrfstune -u → personalize (fstab, crypttab, hostname, user, keymap, locale) →
 mkinitcpio -P (asahi hook **and** dwc3-apple) → GRUB into the existing ESP
-(EFI/BOOT and grub/ only) → @factory snapshot → reboot
+(EFI/BOOT and grub/ only; see System ESP modes below) → @factory snapshot → reboot
 ```
 
 Hard constraints, as refusals not comments:
@@ -123,8 +123,18 @@ Hard constraints, as refusals not comments:
 - Never resize or touch APFS (`7C3457EF-…`), iBoot (`69646961-…`), or Recovery
   (`52637672-…`).
 - Live installer never writes `m1n1/boot.bin`, `vendorfw/`, or `asahi/` on the
-  internal ESP. Writing `EFI/BOOT/BOOTAA64.EFI` and `grub/` is required so the
-  installed system boots. `asahi/` holds wifi/bt pairing; leave it.
+  internal ESP. `asahi/` holds wifi/bt pairing; leave it.
+- **System ESP GRUB, two modes.** U-Boot always loads `\EFI\BOOT\BOOTAA64.EFI`
+  (no EFI boot order). **Piggyback** if that file already exists: unique
+  kernels + `grub/custom.cfg`, abort if `BOOTAA64.EFI` bytes change.
+  **Own** if it is missing (UEFI-only): `grub-mkstandalone` + marker
+  `/omarchy-mac-root`, same recipe as wipe-USB, no `mkfs.vfat`, no
+  `grub-install`, no `update-m1n1`. Hash `m1n1/` / `vendorfw/` / `asahi/`
+  before and after; abort on drift. Do not silently replace an existing GRUB.
+- This machine already is a UEFI-only container plus Omarchy GRUB. Do **not**
+  re-run the Asahi installer to "start over". Hide or replace `BOOTAA64.EFI`
+  only after an ESP tarball is off-disk. Wiping the Omarchy LUKS root (p5)
+  does not test this — m1n1 lives on p4. p5 and p7 are not adjacent.
 - Never create a second ESP on the USB-after-UEFI-only path. The os-package
   path creates the one System ESP via asahi-installer; that is a different
   front door.
@@ -381,8 +391,11 @@ GitHub Releases vs R2 vs split assets.
    `omarchy snapshot restore` sees `@factory`.
 4. Internal ESP `m1n1/boot.bin`, `vendorfw/`, `asahi/` byte-identical before
    and after.
-5. UEFI-only provision on a machine with free space, end to end, timed against
-   the current 8.5 + 14 minute path.
+5. System ESP GRUB own-mode, metal ladder: (1) ESP tarball off-disk, hide
+   `BOOTAA64.EFI`, USB autoboot without interrupting U-Boot; (2) installer
+   own-mode writes GRUB for p7, cold boot with USB unplugged. macOS stays.
+   Do not re-run Asahi's installer. Timed against the current 8.5 + 14
+   minute path once the desktop payload exists.
 6. CI green on `workflow_dispatch` before nightly.
 
 ## Coordination

--- a/test/esp-grub
+++ b/test/esp-grub
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Unprivileged System ESP GRUB tests. Uses temp directories, not NVMe.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../configs/usb/rootfs/omarchy-mac-esp.sh
+source "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
+
+embed="${repo_root}/configs/usb/grub-embed-system.cfg"
+failures=0
+check() {
+  local desc=$1
+  shift
+  if bash -c "$*"; then
+    printf 'ok   - %s\n' "$desc"
+  else
+    printf 'FAIL - %s\n' "$desc"
+    failures=$((failures + 1))
+  fi
+}
+
+work=$(mktemp -d)
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+fake_live=$work/live-esp
+mkdir -p "$fake_live"
+printf 'vmlinuz\n' >"$fake_live/vmlinuz-linux-asahi"
+printf 'initrd\n' >"$fake_live/initramfs-linux-asahi.img"
+
+# --- own mode: UEFI-only ESP (m1n1 + vendorfw, no GRUB) ---
+own=$work/own-esp
+mkdir -p "$own/m1n1" "$own/vendorfw" "$own/asahi"
+printf 'stage2\n' >"$own/m1n1/boot.bin"
+printf 'fw\n' >"$own/vendorfw/firmware.cpio"
+printf 'pair\n' >"$own/asahi/stub_info.json"
+before=$(esp_protected_hashes "$own")
+
+esp_copy_unique_kernels "$fake_live" "$own"
+write_owned_esp_grub "$own" "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" "$embed"
+
+after=$(esp_protected_hashes "$own")
+check "own mode writes BOOTAA64.EFI" "[[ -f '$own/EFI/BOOT/BOOTAA64.EFI' ]]"
+check "own mode writes omarchy-mac-root marker" "[[ -f '$own/omarchy-mac-root' ]]"
+check "own mode grub.cfg names the root UUID" "grep -q 'root=UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' '$own/grub/grub.cfg'"
+check "own mode copies unique vmlinuz" "[[ -f '$own/vmlinuz-omarchy-usb-root' ]]"
+check "own mode copies unique initrd" "[[ -f '$own/initramfs-omarchy-usb-root.img' ]]"
+check "own mode leaves m1n1/vendorfw/asahi hashes unchanged" "[[ '$before' == '$after' ]]"
+check "own mode does not format away m1n1/boot.bin" "[[ -f '$own/m1n1/boot.bin' ]]"
+check "embed searches /omarchy-mac-root" "grep -q 'search --no-floppy --file /omarchy-mac-root' '$embed'"
+check "embed does not search live USB marker" "! grep -q 'search.*omarchy-usb-live' '$embed'"
+
+# --- piggyback: existing GRUB must not be replaced ---
+pig=$work/pig-esp
+mkdir -p "$pig/EFI/BOOT" "$pig/grub" "$pig/m1n1"
+printf 'EXISTING-GRUB\n' >"$pig/EFI/BOOT/BOOTAA64.EFI"
+printf 'menuentry existing {}\n' >"$pig/grub/grub.cfg"
+printf 'stage2\n' >"$pig/m1n1/boot.bin"
+printf 'EXISTING-GRUB\n' >"$work/boot.aa64.expected"
+before_pig=$(esp_protected_hashes "$pig")
+esp_copy_unique_kernels "$fake_live" "$pig"
+write_piggyback_esp_grub "$pig" "11111111-2222-3333-4444-555555555555"
+after_pig=$(esp_protected_hashes "$pig")
+check "piggyback leaves BOOTAA64.EFI bytes unchanged" \
+  "cmp -s '$pig/EFI/BOOT/BOOTAA64.EFI' '$work/boot.aa64.expected'"
+check "piggyback writes custom.cfg" "[[ -f '$pig/grub/custom.cfg' ]]"
+check "piggyback custom.cfg names the new UUID" \
+  "grep -q 'root=UUID=11111111-2222-3333-4444-555555555555' '$pig/grub/custom.cfg'"
+check "piggyback sources custom.cfg from grub.cfg" "grep -q custom.cfg '$pig/grub/grub.cfg'"
+check "piggyback leaves m1n1 hash unchanged" "[[ '$before_pig' == '$after_pig' ]]"
+check "esp_has_bootloader is true for piggyback ESP" "[[ -f '$pig/EFI/BOOT/BOOTAA64.EFI' ]]"
+check "esp_has_bootloader is false on an empty ESP dir" \
+  "[[ ! -f '$work/empty-esp/EFI/BOOT/BOOTAA64.EFI' ]]"
+
+if (( failures > 0 )); then
+  echo "${failures} esp-grub test failure(s)"
+  exit 1
+fi
+echo "esp-grub tests passed"

--- a/test/unit
+++ b/test/unit
@@ -110,9 +110,20 @@ check "install copies initramfs from live ESP" grep -q 'initramfs-linux-asahi.im
 check "install initrd name is unique vs NVMe" grep -q initramfs-omarchy-usb-root.img \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "free-space install uses unique vmlinuz on shared ESP" grep -q vmlinuz-omarchy-usb-root \
-  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
 check "free-space install refuses to change BOOTAA64.EFI" grep -q 'BOOTAA64.EFI changed' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "sh -n omarchy-mac-esp.sh" bash -n \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
+check "esp-grub loopback tests" "${repo_root}/test/esp-grub"
+check "system GRUB embed searches omarchy-mac-root" grep -q /omarchy-mac-root \
+  "${repo_root}/configs/usb/grub-embed-system.cfg"
+check "install offers System ESP GRUB for existing root" grep -q 'Install GRUB for an existing OMARCHYROOT' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "own-mode writes BOOTAA64 when the ESP has none" grep -q write_owned_esp_grub \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "rootfs copies system GRUB embed" grep -q grub-embed-system.cfg \
+  "${repo_root}/builder/build-rootfs.sh"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 

--- a/test/unit
+++ b/test/unit
@@ -124,6 +124,10 @@ check "own-mode writes BOOTAA64 when the ESP has none" grep -q write_owned_esp_g
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "rootfs copies system GRUB embed" grep -q grub-embed-system.cfg \
   "${repo_root}/builder/build-rootfs.sh"
+check "rootfs creates SHARE before copying disk helpers" \
+  awk '/install -d .*usr\/local\/share\/omarchy-mac-iso"/{d=1}
+       /omarchy-mac-disk.sh/{exit !d}' \
+  "${repo_root}/builder/build-rootfs.sh"
 check "usb hook copies vendor firmware" grep -q '/lib/firmware/vendor' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
 


### PR DESCRIPTION
## Summary

When the System ESP has no `BOOTAA64.EFI` (Asahi UEFI-only), the free-space installer now writes GRUB next to m1n1 instead of piggybacking on an existing menu. If GRUB is already there, it still only adds `custom.cfg` and aborts if that file changes. `m1n1` / `vendorfw` / `asahi` hashes must match either way.

Metal on this M2 Max: hid NVMe GRUB, rebuilt the live USB, `mkpart` p7, wrote `BOOTAA64.EFI`, unplugged the stick, got `root@omarchy-mac`. U-Boot only loads one `BOOTAA64.EFI`, so own-mode replaces pancake GRUB; restore the original file and `grub-mkconfig` (`quiet splash`) to get the branded Plymouth unlock back.

Also creates `usr/local/share/omarchy-mac-iso` before copying installer helpers (pacstrap left that dir missing and aborted a full rootfs build). `test/esp-grub` covers own vs piggyback on a fake ESP.