### PR TITLE
Keep installer kernels off grub-mkconfig vmlinuz-* glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,10 @@ GUIDs):
   recipe as wipe-USB, marker `/omarchy-mac-root`, never `mkfs` or
   `update-m1n1`. Kernel/initrd go in `EFI/omarchy/` so a later
   `grub-mkconfig` on the shared ESP does not pick them as `vmlinuz-*`.
-  `m1n1/` / `vendorfw/` / `asahi/` hashes must match after. A fourth
+  `m1n1/` / `vendorfw/` / `asahi/` hashes must match after.
+  Existing `BOOTAA64.EFI` / `grub.cfg` / `custom.cfg` are copied to
+  `*.omarchy-bak` on the ESP before overwrite (timestamped if a bak
+  is already there) so macOS can restore without the USB. A fourth
   menu item writes GRUB for an existing `OMARCHYROOT` without `mkpart`.
   **Own-mode metal 2026-08-25:** hid NVMe GRUB, rebuilt live USB, free-space
   `mkpart` p7, wrote `BOOTAA64.EFI`, USB unplugged → `root@omarchy-mac`.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ GUIDs):
   `BOOTAA64.EFI` already exists (`custom.cfg` only, file unchanged);
   **own** if the ESP is UEFI-only (no GRUB) — same `grub-mkstandalone`
   recipe as wipe-USB, marker `/omarchy-mac-root`, never `mkfs` or
-  `update-m1n1`. Unique `vmlinuz-omarchy-usb-root` / initrd names.
+  `update-m1n1`. Kernel/initrd go in `EFI/omarchy/` so a later
+  `grub-mkconfig` on the shared ESP does not pick them as `vmlinuz-*`.
   `m1n1/` / `vendorfw/` / `asahi/` hashes must match after. A fourth
   menu item writes GRUB for an existing `OMARCHYROOT` without `mkpart`.
   **Own-mode metal 2026-08-25:** hid NVMe GRUB, rebuilt live USB, free-space

--- a/README.md
+++ b/README.md
@@ -169,12 +169,16 @@ GUIDs):
   `BOOTAA64.EFI` already exists (`custom.cfg` only, file unchanged);
   **own** if the ESP is UEFI-only (no GRUB) — same `grub-mkstandalone`
   recipe as wipe-USB, marker `/omarchy-mac-root`, never `mkfs` or
-  `update-m1n1`. Kernel/initrd go in `EFI/omarchy/` so a later
-  `grub-mkconfig` on the shared ESP does not pick them as `vmlinuz-*`.
-  `m1n1/` / `vendorfw/` / `asahi/` hashes must match after.
-  Existing `BOOTAA64.EFI` / `grub.cfg` / `custom.cfg` are copied to
-  `*.omarchy-bak` on the ESP before overwrite (timestamped if a bak
-  is already there) so macOS can restore without the USB. A fourth
+  `update-m1n1`. Kernel/initrd go in `EFI/omarchy/` so **any**
+  `grub-mkconfig` on that ESP (pacman hook on the installed OS, not
+  only the live USB) misses them. Legacy `vmlinuz-omarchy-usb-root` and
+  `initramfs-omarchy-usb-root.img` on the ESP root are removed. `m1n1/` /
+  `vendorfw/` / `asahi/` hashes must match after. Installer backups of
+  `BOOTAA64.EFI` / `grub.cfg` / `custom.cfg` are `*.omarchy-bak` on the
+  ESP (timestamped if a bak already exists). Kernel copies under
+  `EFI/omarchy/` are not backed up — they are 50MiB and reproducible
+  from the live USB. Other suffixes on this machine (`.iso-bak`,
+  `.hand-*`, `.gen-badroot`) are ad-hoc restore copies, not installer. A fourth
   menu item writes GRUB for an existing `OMARCHYROOT` without `mkpart`.
   **Own-mode metal 2026-08-25:** hid NVMe GRUB, rebuilt live USB, free-space
   `mkpart` p7, wrote `BOOTAA64.EFI`, USB unplugged → `root@omarchy-mac`.

--- a/configs/usb/rootfs/omarchy-mac-esp.sh
+++ b/configs/usb/rootfs/omarchy-mac-esp.sh
@@ -12,6 +12,26 @@ esp_protected_hashes() {
   (cd "$esp_mnt" && find asahi m1n1 vendorfw EFI/asahi -type f 2>/dev/null | sort | xargs -r sha256sum) || true
 }
 
+# Copy an existing ESP file to *.omarchy-bak next to it (on the ESP, so
+# macOS can restore without the USB). If that bak already exists, keep
+# it and write a timestamped copy. No-op if the source is missing.
+esp_backup_existing() {
+  local esp_mnt=$1 rel=$2
+  local src=$esp_mnt/$rel dest
+  [[ -f $src ]] || return 0
+  dest=$src.omarchy-bak
+  if [[ -e $dest ]]; then
+    dest=$src.omarchy-bak.$(date +%Y%m%d%H%M%S)
+    n=0
+    while [[ -e $dest ]]; do
+      n=$((n + 1))
+      dest=$src.omarchy-bak.$(date +%Y%m%d%H%M%S).$n
+    done
+  fi
+  cp -a "$src" "$dest" || return 1
+  printf '==> ESP backup %s -> %s\n' "$rel" "${dest#"$esp_mnt"/}" >&2
+}
+
 # Under EFI/omarchy/ so grub-mkconfig 10_linux (/boot/vmlinuz-*) does
 # not treat the installer kernel as the default Omarchy entry.
 esp_copy_unique_kernels() {
@@ -19,6 +39,8 @@ esp_copy_unique_kernels() {
   [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || return 1
   [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || return 1
   mkdir -p "$esp_mnt/EFI/omarchy"
+  esp_backup_existing "$esp_mnt" EFI/omarchy/vmlinuz || return 1
+  esp_backup_existing "$esp_mnt" EFI/omarchy/initramfs.img || return 1
   cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/EFI/omarchy/vmlinuz"
   cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/EFI/omarchy/initramfs.img"
 }
@@ -27,6 +49,8 @@ esp_copy_unique_kernels() {
 write_piggyback_esp_grub() {
   local esp_mnt=$1 root_uuid=$2
   mkdir -p "$esp_mnt/grub"
+  esp_backup_existing "$esp_mnt" grub/custom.cfg || return 1
+  esp_backup_existing "$esp_mnt" grub/grub.cfg || return 1
   : >"$esp_mnt/omarchy-mac-root"
   cat >"$esp_mnt/grub/custom.cfg" <<EOF
 menuentry 'Omarchy Mac (new root $root_uuid)' {
@@ -48,6 +72,11 @@ write_owned_esp_grub() {
   [[ -f $embed_cfg ]] || return 1
   command -v grub-mkstandalone >/dev/null || return 1
   mkdir -p "$esp_mnt/EFI/BOOT" "$esp_mnt/grub"
+  # BOOTAA64 is usually missing in own-mode; grub.cfg often still has the
+  # previous OS menu — that is the file that locked this machine out.
+  esp_backup_existing "$esp_mnt" EFI/BOOT/BOOTAA64.EFI || return 1
+  esp_backup_existing "$esp_mnt" EFI/BOOT/grub.cfg || return 1
+  esp_backup_existing "$esp_mnt" grub/grub.cfg || return 1
   : >"$esp_mnt/omarchy-mac-root"
   cat >"$esp_mnt/grub/grub.cfg" <<EOF
 echo '========================================'

--- a/configs/usb/rootfs/omarchy-mac-esp.sh
+++ b/configs/usb/rootfs/omarchy-mac-esp.sh
@@ -17,12 +17,11 @@ esp_protected_hashes() {
 # it and write a timestamped copy. No-op if the source is missing.
 esp_backup_existing() {
   local esp_mnt=$1 rel=$2
-  local src=$esp_mnt/$rel dest
+  local src=$esp_mnt/$rel dest n=0
   [[ -f $src ]] || return 0
   dest=$src.omarchy-bak
   if [[ -e $dest ]]; then
     dest=$src.omarchy-bak.$(date +%Y%m%d%H%M%S)
-    n=0
     while [[ -e $dest ]]; do
       n=$((n + 1))
       dest=$src.omarchy-bak.$(date +%Y%m%d%H%M%S).$n
@@ -32,17 +31,35 @@ esp_backup_existing() {
   printf '==> ESP backup %s -> %s\n' "$rel" "${dest#"$esp_mnt"/}" >&2
 }
 
+# 64MiB: one kernel + initrd plus slack. A full ESP mid-write is unbootable.
+ESP_MIN_FREE_BYTES=$((64 * 1024 * 1024))
+
+esp_require_free_bytes() {
+  local esp_mnt=$1 need=${2:-$ESP_MIN_FREE_BYTES}
+  local avail_kb
+  avail_kb=$(df -Pk "$esp_mnt" | awk 'NR==2 { print $4 }')
+  [[ $avail_kb =~ ^[0-9]+$ ]] || return 1
+  (( avail_kb * 1024 >= need )) || {
+    printf 'error: ESP %s has %sKiB free, need %s bytes\n' \
+      "$esp_mnt" "$avail_kb" "$need" >&2
+    return 1
+  }
+}
+
 # Under EFI/omarchy/ so grub-mkconfig 10_linux (/boot/vmlinuz-*) does
 # not treat the installer kernel as the default Omarchy entry.
+# Drop the legacy ESP-root names from earlier installs; do not bak
+# EFI/omarchy/ — those files are ours and ~50MiB each copy.
 esp_copy_unique_kernels() {
   local live_esp_mnt=$1 esp_mnt=$2
   [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || return 1
   [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || return 1
+  esp_require_free_bytes "$esp_mnt" || return 1
   mkdir -p "$esp_mnt/EFI/omarchy"
-  esp_backup_existing "$esp_mnt" EFI/omarchy/vmlinuz || return 1
-  esp_backup_existing "$esp_mnt" EFI/omarchy/initramfs.img || return 1
   cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/EFI/omarchy/vmlinuz"
   cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/EFI/omarchy/initramfs.img"
+  rm -f "$esp_mnt/vmlinuz-omarchy-usb-root" \
+    "$esp_mnt/initramfs-omarchy-usb-root.img"
 }
 
 # Piggyback on an OS that already owns BOOTAA64.EFI (custom.cfg only).

--- a/configs/usb/rootfs/omarchy-mac-esp.sh
+++ b/configs/usb/rootfs/omarchy-mac-esp.sh
@@ -12,23 +12,27 @@ esp_protected_hashes() {
   (cd "$esp_mnt" && find asahi m1n1 vendorfw EFI/asahi -type f 2>/dev/null | sort | xargs -r sha256sum) || true
 }
 
+# Under EFI/omarchy/ so grub-mkconfig 10_linux (/boot/vmlinuz-*) does
+# not treat the installer kernel as the default Omarchy entry.
 esp_copy_unique_kernels() {
   local live_esp_mnt=$1 esp_mnt=$2
   [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || return 1
   [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || return 1
-  cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-omarchy-usb-root"
-  cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-omarchy-usb-root.img"
+  mkdir -p "$esp_mnt/EFI/omarchy"
+  cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/EFI/omarchy/vmlinuz"
+  cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/EFI/omarchy/initramfs.img"
 }
 
 # Piggyback on an OS that already owns BOOTAA64.EFI (custom.cfg only).
 write_piggyback_esp_grub() {
   local esp_mnt=$1 root_uuid=$2
   mkdir -p "$esp_mnt/grub"
+  : >"$esp_mnt/omarchy-mac-root"
   cat >"$esp_mnt/grub/custom.cfg" <<EOF
 menuentry 'Omarchy Mac (new root $root_uuid)' {
-  search --no-floppy --file /initramfs-omarchy-usb-root.img --set=root
-  linux /vmlinuz-omarchy-usb-root root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
-  initrd /initramfs-omarchy-usb-root.img
+  search --no-floppy --file /omarchy-mac-root --set=root
+  linux /EFI/omarchy/vmlinuz root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
+  initrd /EFI/omarchy/initramfs.img
 }
 EOF
   if [[ -f $esp_mnt/grub/grub.cfg ]] && ! grep -q custom.cfg "$esp_mnt/grub/grub.cfg"; then
@@ -55,8 +59,8 @@ set default=0
 search --no-floppy --file /omarchy-mac-root --set=root
 
 menuentry 'Omarchy Mac' {
-  linux /vmlinuz-omarchy-usb-root root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
-  initrd /initramfs-omarchy-usb-root.img
+  linux /EFI/omarchy/vmlinuz root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
+  initrd /EFI/omarchy/initramfs.img
 }
 EOF
   cp "$esp_mnt/grub/grub.cfg" "$esp_mnt/EFI/BOOT/grub.cfg"

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -131,6 +131,11 @@ Hard constraints, as refusals not comments:
   `/omarchy-mac-root`, same recipe as wipe-USB, no `mkfs.vfat`, no
   `grub-install`, no `update-m1n1`. Hash `m1n1/` / `vendorfw/` / `asahi/`
   before and after; abort on drift. Do not silently replace an existing GRUB.
+- Installer kernels on the System ESP live in `EFI/omarchy/`, not
+  `vmlinuz-*` on the ESP root. `grub-mkconfig` `10_linux` globs
+  `/boot/vmlinuz-*`; a newer `vmlinuz-omarchy-usb-root` becomes the default
+  and pairs with `initramfs-omarchy-usb-root.img` (no `encrypt` hook).
+  Never run `grub-mkconfig` from the live USB against the System ESP.
 - This machine already is a UEFI-only container plus Omarchy GRUB. Do **not**
   re-run the Asahi installer to "start over". Hide or replace `BOOTAA64.EFI`
   only after an ESP tarball is off-disk. Wiping the Omarchy LUKS root (p5)

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -132,10 +132,14 @@ Hard constraints, as refusals not comments:
   `grub-install`, no `update-m1n1`. Hash `m1n1/` / `vendorfw/` / `asahi/`
   before and after; abort on drift. Do not silently replace an existing GRUB.
 - Installer kernels on the System ESP live in `EFI/omarchy/`, not
-  `vmlinuz-*` on the ESP root. `grub-mkconfig` `10_linux` globs
-  `/boot/vmlinuz-*`; a newer `vmlinuz-omarchy-usb-root` becomes the default
-  and pairs with `initramfs-omarchy-usb-root.img` (no `encrypt` hook).
-  Never run `grub-mkconfig` from the live USB against the System ESP.
+  `vmlinuz-*` on the ESP root. `10_linux` globs `/boot/vmlinuz-*` for
+  **any** `grub-mkconfig` that sees this ESP — including the installed
+  OS's pacman `update-grub` hook, not only a live-USB chroot. A leftover
+  `vmlinuz-omarchy-usb-root` becomes the newest default and pairs with
+  `initramfs-omarchy-usb-root.img` (no `encrypt` hook). Copying into
+  `EFI/omarchy/` also `rm`s those legacy names. Do not bak
+  `EFI/omarchy/` (fills a 500MB ESP). Installer ESP backups are only
+  `*.omarchy-bak` for `BOOTAA64.EFI` and grub configs.
 - This machine already is a UEFI-only container plus Omarchy GRUB. Do **not**
   re-run the Asahi installer to "start over". Hide or replace `BOOTAA64.EFI`
   only after an ESP tarball is off-disk. Wiping the Omarchy LUKS root (p5)

--- a/test/esp-grub
+++ b/test/esp-grub
@@ -30,10 +30,12 @@ printf 'initrd\n' >"$fake_live/initramfs-linux-asahi.img"
 
 # --- own mode: UEFI-only ESP (m1n1 + vendorfw, no GRUB) ---
 own=$work/own-esp
-mkdir -p "$own/m1n1" "$own/vendorfw" "$own/asahi"
+mkdir -p "$own/m1n1" "$own/vendorfw" "$own/asahi" "$own/grub" "$own/EFI/BOOT"
 printf 'stage2\n' >"$own/m1n1/boot.bin"
 printf 'fw\n' >"$own/vendorfw/firmware.cpio"
 printf 'pair\n' >"$own/asahi/stub_info.json"
+printf 'pancake-menu\n' >"$own/grub/grub.cfg"
+printf 'efi-grub\n' >"$own/EFI/BOOT/grub.cfg"
 before=$(esp_protected_hashes "$own")
 
 esp_copy_unique_kernels "$fake_live" "$own"
@@ -43,6 +45,12 @@ after=$(esp_protected_hashes "$own")
 check "own mode writes BOOTAA64.EFI" "[[ -f '$own/EFI/BOOT/BOOTAA64.EFI' ]]"
 check "own mode writes omarchy-mac-root marker" "[[ -f '$own/omarchy-mac-root' ]]"
 check "own mode grub.cfg names the root UUID" "grep -q 'root=UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' '$own/grub/grub.cfg'"
+check "own mode kept pancake grub.cfg as omarchy-bak" \
+  "grep -qx pancake-menu '$own/grub/grub.cfg.omarchy-bak'"
+check "own mode kept EFI/BOOT/grub.cfg as omarchy-bak" \
+  "grep -qx efi-grub '$own/EFI/BOOT/grub.cfg.omarchy-bak'"
+check "own mode does not bak a missing BOOTAA64.EFI" \
+  "[[ ! -e '$own/EFI/BOOT/BOOTAA64.EFI.omarchy-bak' ]]"
 check "own mode copies vmlinuz under EFI/omarchy" "[[ -f '$own/EFI/omarchy/vmlinuz' ]]"
 check "own mode copies initrd under EFI/omarchy" "[[ -f '$own/EFI/omarchy/initramfs.img' ]]"
 check "own mode does not drop vmlinuz-* on the ESP root" \
@@ -57,6 +65,7 @@ pig=$work/pig-esp
 mkdir -p "$pig/EFI/BOOT" "$pig/grub" "$pig/m1n1"
 printf 'EXISTING-GRUB\n' >"$pig/EFI/BOOT/BOOTAA64.EFI"
 printf 'menuentry existing {}\n' >"$pig/grub/grub.cfg"
+printf 'old-custom\n' >"$pig/grub/custom.cfg"
 printf 'stage2\n' >"$pig/m1n1/boot.bin"
 printf 'EXISTING-GRUB\n' >"$work/boot.aa64.expected"
 before_pig=$(esp_protected_hashes "$pig")
@@ -66,6 +75,15 @@ after_pig=$(esp_protected_hashes "$pig")
 check "piggyback leaves BOOTAA64.EFI bytes unchanged" \
   "cmp -s '$pig/EFI/BOOT/BOOTAA64.EFI' '$work/boot.aa64.expected'"
 check "piggyback writes custom.cfg" "[[ -f '$pig/grub/custom.cfg' ]]"
+check "piggyback kept previous custom.cfg as omarchy-bak" \
+  "grep -qx old-custom '$pig/grub/custom.cfg.omarchy-bak'"
+check "piggyback kept grub.cfg as omarchy-bak" \
+  "grep -q 'menuentry existing' '$pig/grub/grub.cfg.omarchy-bak'"
+esp_backup_existing "$pig" grub/custom.cfg
+check "second backup does not clobber the first omarchy-bak" \
+  "grep -qx old-custom '$pig/grub/custom.cfg.omarchy-bak'"
+check "second backup writes a timestamped copy" \
+  "compgen -G '$pig/grub/custom.cfg.omarchy-bak.*' >/dev/null"
 check "piggyback custom.cfg loads EFI/omarchy/vmlinuz" \
   "grep -q '/EFI/omarchy/vmlinuz' '$pig/grub/custom.cfg'"
 check "piggyback custom.cfg names the new UUID" \

--- a/test/esp-grub
+++ b/test/esp-grub
@@ -43,8 +43,10 @@ after=$(esp_protected_hashes "$own")
 check "own mode writes BOOTAA64.EFI" "[[ -f '$own/EFI/BOOT/BOOTAA64.EFI' ]]"
 check "own mode writes omarchy-mac-root marker" "[[ -f '$own/omarchy-mac-root' ]]"
 check "own mode grub.cfg names the root UUID" "grep -q 'root=UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' '$own/grub/grub.cfg'"
-check "own mode copies unique vmlinuz" "[[ -f '$own/vmlinuz-omarchy-usb-root' ]]"
-check "own mode copies unique initrd" "[[ -f '$own/initramfs-omarchy-usb-root.img' ]]"
+check "own mode copies vmlinuz under EFI/omarchy" "[[ -f '$own/EFI/omarchy/vmlinuz' ]]"
+check "own mode copies initrd under EFI/omarchy" "[[ -f '$own/EFI/omarchy/initramfs.img' ]]"
+check "own mode does not drop vmlinuz-* on the ESP root" \
+  "! compgen -G '$own/vmlinuz-*' >/dev/null"
 check "own mode leaves m1n1/vendorfw/asahi hashes unchanged" "[[ '$before' == '$after' ]]"
 check "own mode does not format away m1n1/boot.bin" "[[ -f '$own/m1n1/boot.bin' ]]"
 check "embed searches /omarchy-mac-root" "grep -q 'search --no-floppy --file /omarchy-mac-root' '$embed'"
@@ -64,6 +66,8 @@ after_pig=$(esp_protected_hashes "$pig")
 check "piggyback leaves BOOTAA64.EFI bytes unchanged" \
   "cmp -s '$pig/EFI/BOOT/BOOTAA64.EFI' '$work/boot.aa64.expected'"
 check "piggyback writes custom.cfg" "[[ -f '$pig/grub/custom.cfg' ]]"
+check "piggyback custom.cfg loads EFI/omarchy/vmlinuz" \
+  "grep -q '/EFI/omarchy/vmlinuz' '$pig/grub/custom.cfg'"
 check "piggyback custom.cfg names the new UUID" \
   "grep -q 'root=UUID=11111111-2222-3333-4444-555555555555' '$pig/grub/custom.cfg'"
 check "piggyback sources custom.cfg from grub.cfg" "grep -q custom.cfg '$pig/grub/grub.cfg'"

--- a/test/esp-grub
+++ b/test/esp-grub
@@ -36,6 +36,9 @@ printf 'fw\n' >"$own/vendorfw/firmware.cpio"
 printf 'pair\n' >"$own/asahi/stub_info.json"
 printf 'pancake-menu\n' >"$own/grub/grub.cfg"
 printf 'efi-grub\n' >"$own/EFI/BOOT/grub.cfg"
+# Pre-PR #13 names: 10_linux still globs these if we only add EFI/omarchy/.
+printf 'legacy-vmlinuz\n' >"$own/vmlinuz-omarchy-usb-root"
+printf 'legacy-initrd\n' >"$own/initramfs-omarchy-usb-root.img"
 before=$(esp_protected_hashes "$own")
 
 esp_copy_unique_kernels "$fake_live" "$own"
@@ -53,8 +56,12 @@ check "own mode does not bak a missing BOOTAA64.EFI" \
   "[[ ! -e '$own/EFI/BOOT/BOOTAA64.EFI.omarchy-bak' ]]"
 check "own mode copies vmlinuz under EFI/omarchy" "[[ -f '$own/EFI/omarchy/vmlinuz' ]]"
 check "own mode copies initrd under EFI/omarchy" "[[ -f '$own/EFI/omarchy/initramfs.img' ]]"
-check "own mode does not drop vmlinuz-* on the ESP root" \
-  "! compgen -G '$own/vmlinuz-*' >/dev/null"
+check "own mode removes legacy vmlinuz-omarchy-usb-root" \
+  "[[ ! -e '$own/vmlinuz-omarchy-usb-root' ]]"
+check "own mode removes legacy initramfs-omarchy-usb-root.img" \
+  "[[ ! -e '$own/initramfs-omarchy-usb-root.img' ]]"
+check "own mode does not bak installer kernels under EFI/omarchy" \
+  "[[ ! -e '$own/EFI/omarchy/vmlinuz.omarchy-bak' ]]"
 check "own mode leaves m1n1/vendorfw/asahi hashes unchanged" "[[ '$before' == '$after' ]]"
 check "own mode does not format away m1n1/boot.bin" "[[ -f '$own/m1n1/boot.bin' ]]"
 check "embed searches /omarchy-mac-root" "grep -q 'search --no-floppy --file /omarchy-mac-root' '$embed'"

--- a/test/unit
+++ b/test/unit
@@ -109,7 +109,7 @@ check "install copies initramfs from live ESP" grep -q 'initramfs-linux-asahi.im
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install initrd name is unique vs NVMe" grep -q initramfs-omarchy-usb-root.img \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
-check "free-space install uses unique vmlinuz on shared ESP" grep -q vmlinuz-omarchy-usb-root \
+check "System ESP kernels live under EFI/omarchy" grep -q 'EFI/omarchy/vmlinuz' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
 check "free-space install refuses to change BOOTAA64.EFI" grep -q 'BOOTAA64.EFI changed' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"

--- a/test/unit
+++ b/test/unit
@@ -111,6 +111,8 @@ check "install initrd name is unique vs NVMe" grep -q initramfs-omarchy-usb-root
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "System ESP kernels live under EFI/omarchy" grep -q 'EFI/omarchy/vmlinuz' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
+check "ESP writes backup existing boot files" grep -q omarchy-bak \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
 check "free-space install refuses to change BOOTAA64.EFI" grep -q 'BOOTAA64.EFI changed' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "sh -n omarchy-mac-esp.sh" bash -n \

--- a/test/unit
+++ b/test/unit
@@ -113,6 +113,9 @@ check "System ESP kernels live under EFI/omarchy" grep -q 'EFI/omarchy/vmlinuz' 
   "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
 check "ESP writes backup existing boot files" grep -q omarchy-bak \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
+check "legacy ESP-root installer kernels are removed" grep -q \
+  'rm -f "$esp_mnt/vmlinuz-omarchy-usb-root"' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
 check "free-space install refuses to change BOOTAA64.EFI" grep -q 'BOOTAA64.EFI changed' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "sh -n omarchy-mac-esp.sh" bash -n \


### PR DESCRIPTION
## Summary

`grub-mkconfig` `10_linux` globs `/boot/vmlinuz-*`. After a hole install the shared System ESP had a newer `vmlinuz-omarchy-usb-root`, so that became the default and paired with `initramfs-omarchy-usb-root.img` (no `encrypt` hook). Passphrase never ran.

Installer kernels now go in `EFI/omarchy/`, which that glob does not see. Own/piggyback GRUB paths updated. Wipe-USB names are unchanged (private ESP).