### PR TITLE
Pacstrap the Omarchy shell into the USB rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ SDDM, `omarchy` from those tarballs. Still does **not** pacstrap
 `linux-asahi` or `asahi-scripts` (host ESP). Vendor firmware is copied from
 the internal ESP at boot. Default `--usb` without `--rootfs` still hangs at
 busybox pid 1. Override size with `OMARCHY_USB_PAYLOAD_BYTES`; package
-search with `OMARCHY_LOCAL_PACKAGES`.
+search with `OMARCHY_LOCAL_PACKAGES`. Proven on metal 2026-08-25 (Lexar,
+8GiB `OMARCHYLIVE`, `bootflow` `usb_mass_storage`): autologin
+`root@omarchy-mac-live`, `pacman -Q` reported `omarchy 4.0.0-1`,
+`hyprland 0.56.1-3`, `quickshell 0.3.1-1`, `sddm 0.21.0-7`. Still a tty,
+not a graphical session.
 
 Flash (destroys the target stick):
 

--- a/README.md
+++ b/README.md
@@ -80,17 +80,21 @@ initramfs with `dwc3-apple`) and a btrfs payload labelled `OMARCHYLIVE`
 (subvol `@`, tiny busybox `/sbin/init`). No root required. Copying files
 onto an existing FAT stick is not enough — the payload is its own partition.
 
-Systemd userspace (not the Omarchy desktop) — needs root, `arch-install-scripts`:
+Systemd userspace plus the Omarchy *shell* packages — needs root,
+`arch-install-scripts`, and local `omarchy-*.pkg.tar.*` (default
+`~/.local/share/omarchy/build-output`):
 
 ```
 sudo ./bin/omarchy-mac-iso-make --usb --rootfs
 ```
 
-Autologin root on tty1. Payload has NetworkManager, `iwd`, Asahi mesa,
-asahi-audio, gum, `hid_apple fnmode=1`, `appledrm show_notch=1`, parted,
-gptfdisk, btrfs-progs, dosfstools, and grub. Vendor firmware is copied from
+Autologin root on tty1 (`multi-user.target`, not SDDM). Payload is 8GiB
+btrfs: NetworkManager, Asahi mesa / asahi-audio, gum, Hyprland, Quickshell,
+SDDM, `omarchy` from those tarballs. Still does **not** pacstrap
+`linux-asahi` or `asahi-scripts` (host ESP). Vendor firmware is copied from
 the internal ESP at boot. Default `--usb` without `--rootfs` still hangs at
-busybox pid 1.
+busybox pid 1. Override size with `OMARCHY_USB_PAYLOAD_BYTES`; package
+search with `OMARCHY_LOCAL_PACKAGES`.
 
 Flash (destroys the target stick):
 

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -62,12 +62,23 @@ find_local_pkg() {
 
 loop=""
 mnt=""
+
+# pacstrap rbind-mounts /dev, /proc, /sys. umount of @ is busy until those
+# are gone. -R walks children first.
+unmount_tree() {
+  local dir=$1
+  [[ -n $dir && -d $dir ]] || return 0
+  findmnt "$dir" >/dev/null || return 0
+  umount -R "$dir" 2>/dev/null && return 0
+  local target
+  while read -r target; do
+    umount "$target" 2>/dev/null || true
+  done < <(findmnt -Rnc -o TARGET -- "$dir" 2>/dev/null | tac)
+  umount "$dir" 2>/dev/null || umount -l "$dir"
+}
+
 cleanup() {
-  if [[ -n $mnt ]]; then
-    umount "$mnt/boot" 2>/dev/null || true
-    umount "$mnt/run" 2>/dev/null || true
-    umount "$mnt" 2>/dev/null || true
-  fi
+  unmount_tree "$mnt" || true
   if [[ -n $loop ]]; then
     losetup -d "$loop" 2>/dev/null || true
   fi
@@ -204,7 +215,10 @@ systemctl --root="$mnt" set-default multi-user.target
 log "payload used $(du -sh "$mnt" | cut -f1) on the @ subvolume"
 
 sync
-umount "$mnt"
+unmount_tree "$mnt" || {
+  findmnt -R "$mnt" >&2 || true
+  fail "could not unmount payload $mnt"
+}
 mnt=""
 losetup -d "$loop"
 loop=""

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -38,9 +38,16 @@ for pkg in "${forbidden_packages[@]}"; do
 done
 
 find_local_pkg() {
-  local name=$1 dir f
+  local name=$1 dir f sudo_home=""
+  # sudo ./bin/omarchy-mac-iso-make sets HOME=/root; tarballs live in
+  # the invoking user's ~/.local/share/omarchy/build-output.
+  if [[ -n ${SUDO_USER:-} ]]; then
+    sudo_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+  fi
   for dir in \
     ${OMARCHY_LOCAL_PACKAGES:+"$OMARCHY_LOCAL_PACKAGES"} \
+    ${sudo_home:+"$sudo_home/.local/share/omarchy/build-output"} \
+    ${OMARCHY_PATH:+"$OMARCHY_PATH/build-output"} \
     "${HOME}/.local/share/omarchy/build-output" \
     "${repo_root}/../omarchy-mac/build-output"; do
     [[ -d $dir ]] || continue
@@ -106,7 +113,7 @@ pacstrap -c "$mnt" base networkmanager iwd mesa asahi-audio \
 local_pkgs=()
 for name in omarchy-keyring ttf-jetbrains-mono-nerd-basic omarchy-settings omarchy; do
   f=$(find_local_pkg "$name") \
-    || fail "no $name-*.pkg.tar.* — set OMARCHY_LOCAL_PACKAGES or build omarchy first"
+    || fail "no $name-*.pkg.tar.* (sudo HOME is /root; set OMARCHY_LOCAL_PACKAGES or build omarchy as $SUDO_USER)"
   local_pkgs+=("$f")
 done
 log "pacman -U ${local_pkgs[*]##*/}"

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 # Usage: build-rootfs.sh <out-payload.img>
-# Pacstrap Arch Linux ARM `base` onto btrfs @ (label OMARCHYLIVE).
-# Needs root. This is S3: systemd userspace, not the Omarchy desktop.
+# Pacstrap Arch Linux ARM `base` plus the Omarchy shell (hyprland,
+# quickshell, sddm, omarchy from local tarballs) onto btrfs @ (label
+# OMARCHYLIVE). Needs root. Live session stays multi-user.target /
+# autologin — not a graphical login. Do not pacstrap linux-asahi or
+# asahi-scripts (their hooks mount the host ESP).
 set -euo pipefail
 
 out="$1"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-payload_bytes=${OMARCHY_USB_PAYLOAD_BYTES:-$((3 * 1024 * 1024 * 1024))}
+# Shell packages no longer fit in 3GiB (base + mesa was ~2.1GiB).
+payload_bytes=${OMARCHY_USB_PAYLOAD_BYTES:-$((8 * 1024 * 1024 * 1024))}
+packages_file=$repo_root/configs/usb/rootfs/packages
+forbidden_packages=(linux-asahi asahi-scripts m1n1 uboot-asahi)
 
 log() { printf '==> %s\n' "$*" >&2; }
 fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
@@ -15,6 +21,37 @@ fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
 command -v pacstrap >/dev/null || fail "pacstrap not found — pacman -S arch-install-scripts"
 command -v mkfs.btrfs >/dev/null || fail "need btrfs-progs"
 command -v losetup >/dev/null || fail "need losetup"
+
+read_package_list() {
+  local pkg
+  [[ -f $packages_file ]] || fail "missing $packages_file"
+  while read -r pkg; do
+    [[ -z $pkg || $pkg == \#* ]] && continue
+    printf '%s\n' "$pkg"
+  done <"$packages_file"
+}
+
+for pkg in "${forbidden_packages[@]}"; do
+  if read_package_list | grep -qx "$pkg"; then
+    fail "refusing to pacstrap $pkg (mounts or rewrites the host ESP)"
+  fi
+done
+
+find_local_pkg() {
+  local name=$1 dir f
+  for dir in \
+    ${OMARCHY_LOCAL_PACKAGES:+"$OMARCHY_LOCAL_PACKAGES"} \
+    "${HOME}/.local/share/omarchy/build-output" \
+    "${repo_root}/../omarchy-mac/build-output"; do
+    [[ -d $dir ]] || continue
+    for f in "$dir"/${name}-*.pkg.tar.*; do
+      [[ -f $f ]] || continue
+      printf '%s\n' "$f"
+      return 0
+    done
+  done
+  return 1
+}
 
 loop=""
 mnt=""
@@ -59,10 +96,28 @@ mkdir -p "$mnt/run" "$mnt/boot"
 mount -t tmpfs tmpfs "$mnt/run"
 mount -t tmpfs tmpfs "$mnt/boot"
 
-log "pacstrap base networkmanager iwd mesa asahi-audio gum"
+mapfile -t extra_packages < <(read_package_list)
+log "pacstrap base networkmanager iwd mesa asahi-audio gum + ${extra_packages[*]}"
 pacstrap -c "$mnt" base networkmanager iwd mesa asahi-audio \
   alsa-ucm-conf-asahi speakersafetyd pipewire-pulse gum \
-  parted gptfdisk btrfs-progs dosfstools grub
+  parted gptfdisk btrfs-progs dosfstools grub \
+  "${extra_packages[@]}"
+
+local_pkgs=()
+for name in omarchy-keyring ttf-jetbrains-mono-nerd-basic omarchy-settings omarchy; do
+  f=$(find_local_pkg "$name") \
+    || fail "no $name-*.pkg.tar.* — set OMARCHY_LOCAL_PACKAGES or build omarchy first"
+  local_pkgs+=("$f")
+done
+log "pacman -U ${local_pkgs[*]##*/}"
+pacman -U --noconfirm --needed --root "$mnt" --cachedir /var/cache/pacman/pkg \
+  "${local_pkgs[@]}"
+
+install -m644 "$repo_root/configs/usb/rootfs/pacman.conf" "$mnt/etc/pacman.conf"
+[[ -f /etc/pacman.d/mirrorlist ]] || fail "host /etc/pacman.d/mirrorlist missing"
+install -m644 /etc/pacman.d/mirrorlist "$mnt/etc/pacman.d/mirrorlist"
+[[ -f /etc/pacman.d/mirrorlist.asahi-alarm ]] || fail "host asahi-alarm mirrorlist missing"
+install -m644 /etc/pacman.d/mirrorlist.asahi-alarm "$mnt/etc/pacman.d/mirrorlist.asahi-alarm"
 
 umount "$mnt/boot"
 umount "$mnt/run"

--- a/builder/build-usb-image.sh
+++ b/builder/build-usb-image.sh
@@ -127,7 +127,7 @@ cp "$repo_root/configs/usb/grub.cfg" "$out_dir/grub.cfg"
 
 git_ref="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 payload_kind="busybox pid 1"
-[[ ${OMARCHY_USB_ROOTFS:-} == 1 ]] && payload_kind="systemd base (pacstrap)"
+[[ ${OMARCHY_USB_ROOTFS:-} == 1 ]] && payload_kind="systemd + Omarchy shell (hyprland/quickshell/sddm, multi-user.target)"
 cat > "$out_dir/BUILD_INFO" <<EOF
 artifact: omarchy-mac-usb
 built_from_ref: $git_ref

--- a/configs/usb/rootfs/packages
+++ b/configs/usb/rootfs/packages
@@ -1,0 +1,14 @@
+# Extra packages on the USB rootfs (S3). Not linux-asahi, m1n1,
+# uboot-asahi, or asahi-scripts — those hooks mount the host ESP.
+# The `omarchy` tarball's depends; local .pkg.tar files are added in
+# build-rootfs.sh via OMARCHY_LOCAL_PACKAGES.
+hyprland
+quickshell
+uwsm
+sddm
+xdg-desktop-portal-hyprland
+snapper
+plymouth
+gnome-keyring
+pacman-contrib
+perl

--- a/configs/usb/rootfs/pacman.conf
+++ b/configs/usb/rootfs/pacman.conf
@@ -1,0 +1,29 @@
+# Payload pacman.conf. Copied onto the live rootfs at build time.
+# linux-asahi / asahi-scripts are still not pacstrapped (host ESP).
+[options]
+HoldPkg = pacman glibc
+Architecture = aarch64
+CheckSpace
+ParallelDownloads = 5
+SigLevel = Required DatabaseOptional
+LocalFileSigLevel = Optional
+
+# Omarchy's pkgs.omarchy.org is x86_64 only.
+[omarchy-aarch64]
+SigLevel = Optional TrustAll
+Server = https://github.com/omarchy-mac/omarchy-pkgs-aarch64/releases/download/edge
+
+[asahi-alarm]
+Include = /etc/pacman.d/mirrorlist.asahi-alarm
+
+[core]
+Include = /etc/pacman.d/mirrorlist
+
+[extra]
+Include = /etc/pacman.d/mirrorlist
+
+[alarm]
+Include = /etc/pacman.d/mirrorlist
+
+[aur]
+Include = /etc/pacman.d/mirrorlist

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -347,15 +347,16 @@ the busybox tree on `@` with Arch `base` / systemd.
 autologin root shell, `nmtui` + brcmfmac scan, then `ping www.google.com`.
 wlan0 is missing until nmtui Rescan; after that both nmtui Activate and
 `nmcli … password` have worked. `gum` 0.17.0 and `hid_apple fnmode=1`
-proven on metal. Not the Omarchy desktop. Asahi mesa / asahi-audio /
-speakersafetyd / gum and `fnmode=1` / `show_notch=1` go in this payload
-(not `asahi-scripts`).
-Then the fork's package set →
-provisioning with hardware-specific work that is *not* per-machine done at
-build time (audio stack, `fnmode`, notch modprobe) → defer keymap / user /
-hostname / anything that reads this panel to first boot or the installer →
-produce `root.img` (btrfs, minimal, sparse, **not** internally zstd'd for
-publication).
+proven on metal. **2026-08-25:** also pacstraps the `omarchy` package
+depends (Hyprland, Quickshell, SDDM, uwsm) and `pacman -U`s local
+`omarchy` / `omarchy-settings` / `omarchy-keyring` /
+`ttf-jetbrains-mono-nerd-basic` tarballs. Live target stays
+`multi-user.target`. Still not `linux-asahi` / `asahi-scripts`. Default
+payload 8GiB. Full `omarchy-base.packages` (Chromium, etc.) and a
+graphical live session are later. `fnmode=1` / `show_notch=1` stay in
+this payload. Defer keymap / user / hostname to first boot or the
+installer. Produce `root.img` (btrfs, minimal, sparse, **not** internally
+zstd'd for publication).
 
 Regenerate the btrfs UUID at install (`btrfstune -u`).
 

--- a/plans/apple-silicon-image.md
+++ b/plans/apple-silicon-image.md
@@ -351,8 +351,10 @@ proven on metal. **2026-08-25:** also pacstraps the `omarchy` package
 depends (Hyprland, Quickshell, SDDM, uwsm) and `pacman -U`s local
 `omarchy` / `omarchy-settings` / `omarchy-keyring` /
 `ttf-jetbrains-mono-nerd-basic` tarballs. Live target stays
-`multi-user.target`. Still not `linux-asahi` / `asahi-scripts`. Default
-payload 8GiB. Full `omarchy-base.packages` (Chromium, etc.) and a
+`multi-user.target`. **Metal 2026-08-25:** Lexar 8GiB payload, `pacman -Q`
+`omarchy 4.0.0-1` `hyprland 0.56.1-3` `quickshell 0.3.1-1` `sddm 0.21.0-7`
+at `root@omarchy-mac-live`. Still not `linux-asahi` / `asahi-scripts`.
+Default payload 8GiB. Full `omarchy-base.packages` (Chromium, etc.) and a
 graphical live session are later. `fnmode=1` / `show_notch=1` stay in
 this payload. Defer keymap / user / hostname to first boot or the
 installer. Produce `root.img` (btrfs, minimal, sparse, **not** internally

--- a/test/unit
+++ b/test/unit
@@ -70,6 +70,8 @@ check "rootfs extra packages omit asahi-scripts" \
   bash -c '! grep -qx asahi-scripts "'"${repo_root}"'/configs/usb/rootfs/packages"'
 check "rootfs installs local omarchy tarball" grep -q 'omarchy-keyring' \
   "${repo_root}/builder/build-rootfs.sh"
+check "rootfs finds local packages via SUDO_USER home" grep -q SUDO_USER \
+  "${repo_root}/builder/build-rootfs.sh"
 check "rootfs copies payload pacman.conf" grep -q 'configs/usb/rootfs/pacman.conf' \
   "${repo_root}/builder/build-rootfs.sh"
 check "payload pacman.conf has omarchy-aarch64" grep -q '\[omarchy-aarch64\]' \

--- a/test/unit
+++ b/test/unit
@@ -80,6 +80,8 @@ check "rootfs default payload is 8GiB" grep -q '8 \* 1024 \* 1024 \* 1024' \
   "${repo_root}/builder/build-rootfs.sh"
 check "rootfs still tmpfs-isolates /boot" grep -q 'mount -t tmpfs tmpfs "$mnt/boot"' \
   "${repo_root}/builder/build-rootfs.sh"
+check "rootfs unmounts nested pacstrap mounts" grep -q 'umount -R' \
+  "${repo_root}/builder/build-rootfs.sh"
 check "hid_apple fnmode=1 is in the tree" grep -q 'fnmode=1' \
   "${repo_root}/configs/usb/modprobe.d/hid_apple.conf"
 check "install script refuses Apple partition GUIDs" grep -q 7c3457ef \

--- a/test/unit
+++ b/test/unit
@@ -62,6 +62,22 @@ check "NM live conf disables polkit auth" grep -q 'auth-polkit=false' \
   "${repo_root}/configs/usb/rootfs/nm-live.conf"
 check "rootfs pacstraps mesa and gum" grep -q ' mesa ' \
   "${repo_root}/builder/build-rootfs.sh"
+check "rootfs extra packages include hyprland" grep -qx hyprland \
+  "${repo_root}/configs/usb/rootfs/packages"
+check "rootfs extra packages omit linux-asahi" \
+  bash -c '! grep -qx linux-asahi "'"${repo_root}"'/configs/usb/rootfs/packages"'
+check "rootfs extra packages omit asahi-scripts" \
+  bash -c '! grep -qx asahi-scripts "'"${repo_root}"'/configs/usb/rootfs/packages"'
+check "rootfs installs local omarchy tarball" grep -q 'omarchy-keyring' \
+  "${repo_root}/builder/build-rootfs.sh"
+check "rootfs copies payload pacman.conf" grep -q 'configs/usb/rootfs/pacman.conf' \
+  "${repo_root}/builder/build-rootfs.sh"
+check "payload pacman.conf has omarchy-aarch64" grep -q '\[omarchy-aarch64\]' \
+  "${repo_root}/configs/usb/rootfs/pacman.conf"
+check "rootfs default payload is 8GiB" grep -q '8 \* 1024 \* 1024 \* 1024' \
+  "${repo_root}/builder/build-rootfs.sh"
+check "rootfs still tmpfs-isolates /boot" grep -q 'mount -t tmpfs tmpfs "$mnt/boot"' \
+  "${repo_root}/builder/build-rootfs.sh"
 check "hid_apple fnmode=1 is in the tree" grep -q 'fnmode=1' \
   "${repo_root}/configs/usb/modprobe.d/hid_apple.conf"
 check "install script refuses Apple partition GUIDs" grep -q 7c3457ef \


### PR DESCRIPTION
## Summary

The live `--usb --rootfs` payload now includes the Omarchy shell: Hyprland, Quickshell, SDDM, uwsm, and local `omarchy` / `omarchy-settings` / `omarchy-keyring` tarballs. It still does not pacstrap `linux-asahi` or `asahi-scripts` (host ESP). Live boot stays tty autologin, not a graphical session.

Default payload is 8GiB (~2.9GiB used). `sudo` builds find tarballs in `SUDO_USER`'s home. Nested pacstrap mounts are `umount -R`'d.

Metal on this M2 Max (2026-08-25): Lexar 8GiB `OMARCHYLIVE`, `pacman -Q` `omarchy 4.0.0-1`, `hyprland 0.56.1-3`, `quickshell 0.3.1-1`, `sddm 0.21.0-7`.