### PR TITLE
Graphical persistent install with SDDM and replace-existing-root

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,11 @@ GUIDs):
   Proven from Omarchy and from the live USB (2026-08-23): Lexar ↔ 14.5G stick,
   `gum 2.0.0`, `fnmode=1`.
 - **Install (wipe USB)** — GPT ESP (`OMARCHYBOOT`) + btrfs root filling the
-  disk. Proven on an M2 Max (2026-08-24): 14.5G stick, autologin
-  `root@omarchy-mac`, nmtui Rescan then Wi-Fi ping. Warm USB boot worked.
-  GRUB must search `/omarchy-usb-install`, not `/initramfs-linux-asahi.img`
+  disk. Prompts for a desktop user, enables SDDM autologin
+  (`omarchy.desktop` / Hyprland uwsm) and `graphical.target`. Live USB
+  stays tty autologin. Proven on an M2 Max (2026-08-24): 14.5G stick,
+  then console-only; graphical session not metal-proven yet. GRUB must
+  search `/omarchy-usb-install`, not `/initramfs-linux-asahi.img`
   (that file is the NVMe LUKS initramfs).
 - **Install into free space** — `parted mkpart` in an existing GPT hole only.
   Never `mklabel`/`wipefs`. Proven on the Lexar hole (keep live

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ GUIDs):
   `gum 2.0.0`, `fnmode=1`.
 - **Install (wipe USB)** — GPT ESP (`OMARCHYBOOT`) + btrfs root filling the
   disk. Prompts for a desktop user, enables SDDM autologin
-  (`omarchy.desktop` / Hyprland uwsm) and `graphical.target`. Live USB
+  (`omarchy.desktop` in `/usr/local/share/wayland-sessions`, Hyprland
+  uwsm) and `graphical.target`. Live USB
   stays tty autologin. Proven on an M2 Max (2026-08-24): 14.5G stick,
   then console-only; graphical session not metal-proven yet. GRUB must
   search `/omarchy-usb-install`, not `/initramfs-linux-asahi.img`

--- a/bin/omarchy-mac-iso-refresh-live
+++ b/bin/omarchy-mac-iso-refresh-live
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Copy the current installer onto the plugged-in live USB (OMARCHYLIVE +
+# OMARCHYISO) without an 8.6G --usb --rootfs rebuild.
+set -euo pipefail
+(( EUID == 0 )) || { echo "run as root: sudo $0"; exit 1; }
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+live=""
+iso=""
+for d in /dev/sda2 /dev/sdb2 /dev/sdc2; do
+  [[ -b $d ]] || continue
+  label=$(blkid -s LABEL -o value "$d" 2>/dev/null || true)
+  [[ $label == OMARCHYLIVE ]] || continue
+  live=$d
+  break
+done
+for d in /dev/sda1 /dev/sdb1 /dev/sdc1; do
+  [[ -b $d ]] || continue
+  label=$(blkid -s LABEL -o value "$d" 2>/dev/null || true)
+  [[ $label == OMARCHYISO ]] || continue
+  iso=$d
+  break
+done
+[[ -n $live ]] || { echo "error: OMARCHYLIVE not found (plug in the live USB)"; exit 1; }
+[[ -n $iso ]] || { echo "error: OMARCHYISO not found"; exit 1; }
+
+mnt=$(findmnt -n -o TARGET "$live" || true)
+mounted_live=0
+if [[ -z $mnt ]]; then
+  mnt=$(mktemp -d)
+  mount -o subvol=@ "$live" "$mnt"
+  mounted_live=1
+fi
+iso_mnt=$(findmnt -n -o TARGET "$iso" || true)
+mounted_iso=0
+if [[ -z $iso_mnt ]]; then
+  iso_mnt=$(mktemp -d)
+  mount "$iso" "$iso_mnt"
+  mounted_iso=1
+fi
+cleanup() {
+  if (( mounted_iso == 1 )); then
+    umount "$iso_mnt" 2>/dev/null || true
+    rmdir "$iso_mnt" 2>/dev/null || true
+  fi
+  if (( mounted_live == 1 )); then
+    umount "$mnt" 2>/dev/null || true
+    rmdir "$mnt" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+share=$mnt/usr/local/share/omarchy-mac-iso
+install -d "$mnt/usr/local/sbin" "$share" "$share/initcpio/hooks" "$share/initcpio/install" "$mnt/root"
+install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-install" "$mnt/usr/local/sbin/omarchy-mac-install"
+install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-live-welcome" "$mnt/usr/local/sbin/omarchy-mac-live-welcome"
+install -m644 "$repo_root/configs/usb/rootfs/root-bash-profile" "$mnt/root/.bash_profile"
+install -m644 "$repo_root/configs/usb/rootfs/issue" "$mnt/etc/issue"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" "$share/omarchy-mac-disk.sh"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" "$mnt/usr/local/sbin/omarchy-mac-disk.sh"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-esp.sh" "$share/omarchy-mac-esp.sh"
+install -m644 "$repo_root/configs/usb/grub-embed.cfg" "$share/grub-embed.cfg"
+install -m644 "$repo_root/configs/usb/grub-embed-install.cfg" "$share/grub-embed-install.cfg"
+install -m644 "$repo_root/configs/usb/grub-embed-system.cfg" "$share/grub-embed-system.cfg"
+install -m644 "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" "$share/mkinitcpio-install.conf"
+install -m644 "$repo_root/configs/usb-initcpio/hooks/omarchy-usb-wait" "$share/initcpio/hooks/omarchy-usb-wait"
+install -m644 "$repo_root/configs/usb-initcpio/install/omarchy-usb-wait" "$share/initcpio/install/omarchy-usb-wait"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-asahi-hw.service" \
+  "$mnt/etc/systemd/system/omarchy-mac-asahi-hw.service"
+if [[ -d $iso_mnt/grub ]]; then
+  install -m644 "$repo_root/configs/usb/grub.cfg" "$iso_mnt/grub/grub.cfg"
+fi
+echo "==> copied installer onto the live USB"
+
+echo "==> pacman --sysroot $mnt -Sy"
+pacman --sysroot "$mnt" -Sy --noconfirm
+echo "==> pacman --sysroot $mnt -S foot xdg-terminal-exec chromium"
+pacman --sysroot "$mnt" -S --noconfirm --needed foot xdg-terminal-exec chromium
+[[ -x $mnt/usr/bin/foot && -x $mnt/usr/bin/chromium && -x $mnt/usr/bin/xdg-terminal-exec ]] \
+  || { echo "error: desktop packages missing after install"; exit 1; }
+
+out=/tmp/initramfs-omarchy-usb-root.img
+kver=$(uname -r)
+mkinitcpio -n \
+  -c "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" \
+  -D /usr/lib/initcpio \
+  -D "$repo_root/configs/usb-initcpio" \
+  -k "$kver" \
+  -g "$out"
+cp -a "$out" "$iso_mnt/initramfs-linux-asahi.img"
+sync
+grep -q 'Reinstall an existing Omarchy root' "$mnt/usr/local/sbin/omarchy-mac-install"
+echo "==> wrote $iso_mnt/initramfs-linux-asahi.img"
+echo "==> Shutdown, boot the live USB."

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -152,6 +152,11 @@ install -d "$mnt/usr/local/sbin"
 install -d "$mnt/usr/local/share/omarchy-mac-iso"
 install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-install" \
   "$mnt/usr/local/sbin/omarchy-mac-install"
+install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-live-welcome" \
+  "$mnt/usr/local/sbin/omarchy-mac-live-welcome"
+install -d "$mnt/root"
+install -m644 "$repo_root/configs/usb/rootfs/root-bash-profile" \
+  "$mnt/root/.bash_profile"
 install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" \
   "$mnt/usr/local/share/omarchy-mac-iso/omarchy-mac-disk.sh"
 install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" \

--- a/configs/usb-initcpio/hooks/omarchy-usb-wait
+++ b/configs/usb-initcpio/hooks/omarchy-usb-wait
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MIT
 #
 # Root is on USB. dwc3-apple can take several seconds. Wait for the
-# UUID (or OMARCHYROOT) before the filesystems hook mounts it.
+# cmdline UUID before the filesystems hook mounts it. Do not treat
+# LABEL=OMARCHYROOT as success when a UUID is set: NVMe hole installs
+# use that label too, so the wait would return before USB enumerates.
 
 hang() {
   echo "==> $*" >/dev/console
@@ -35,12 +37,12 @@ run_hook() {
 
   uuid=$(root_uuid_from_cmdline || true)
   i=0
-  while [ "$i" -lt 30 ]; do
+  while [ "$i" -lt 45 ]; do
     if [ -n "$uuid" ] && [ -e /dev/disk/by-uuid/"$uuid" ]; then
       echo "==> omarchy-usb-wait: root UUID=$uuid" >/dev/console
       return 0
     fi
-    if [ -e /dev/disk/by-label/OMARCHYROOT ]; then
+    if [ -z "$uuid" ] && [ -e /dev/disk/by-label/OMARCHYROOT ]; then
       echo "==> omarchy-usb-wait: root label=OMARCHYROOT" >/dev/console
       return 0
     fi

--- a/configs/usb-initcpio/install/omarchy-usb-wait
+++ b/configs/usb-initcpio/install/omarchy-usb-wait
@@ -7,7 +7,8 @@ build() {
 
 help() {
   cat <<HELPEOF
-Wait for a USB root filesystem (UUID from the kernel cmdline, or label
-OMARCHYROOT) before the filesystems hook mounts it.
+Wait for a USB root filesystem (UUID from the kernel cmdline) before
+the filesystems hook mounts it. LABEL=OMARCHYROOT is only used when
+the cmdline has no UUID — that label also exists on NVMe hole installs.
 HELPEOF
 }

--- a/configs/usb/grub.cfg
+++ b/configs/usb/grub.cfg
@@ -10,7 +10,7 @@ search --no-floppy --file /initramfs-omarchy-usb.img --set=root
 
 menuentry 'Omarchy Mac live (USB)' {
   echo 'GRUB is running from the USB ESP'
-  linux /vmlinuz-linux-asahi loglevel=3
+  linux /vmlinuz-linux-asahi loglevel=3 quiet
   initrd /initramfs-omarchy-usb.img
 }
 

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -1,10 +1,5 @@
-Omarchy Mac live USB (systemd). Not the installer yet.
-Wi-Fi: nmtui Rescan until SSIDs appear, then
-       nmtui Activate  or  nmcli device wifi connect 'SSID' password 'PSK'
-USB:   nmcli device connect enu1
-Check: cat /sys/module/hid_apple/parameters/fnmode   (want 1)
-       gum --version
-Install (WIP, wipes the target disk): omarchy-mac-install
-         gum: Install to a disk (persistent root) or Clone this live USB
+Omarchy Mac live USB. tty1 autologin starts the install prompt.
+Wi-Fi: nmtui Rescan until SSIDs appear, then Activate
+Install: omarchy-mac-install   (never touches APFS; you pick the disk)
 
 

--- a/configs/usb/rootfs/issue
+++ b/configs/usb/rootfs/issue
@@ -1,5 +1,4 @@
 Omarchy Mac live USB. tty1 autologin starts the install prompt.
-Wi-Fi: nmtui Rescan until SSIDs appear, then Activate
-Install: omarchy-mac-install   (never touches APFS; you pick the disk)
+Install: omarchy-mac-install   (never touches APFS; you pick the partition)
 
 

--- a/configs/usb/rootfs/omarchy-mac-asahi-hw.service
+++ b/configs/usb/rootfs/omarchy-mac-asahi-hw.service
@@ -5,7 +5,7 @@ After=local-fs.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/bash -c 'echo 1 >/sys/module/hid_apple/parameters/fnmode 2>/dev/null; echo 1 >/sys/module/appledrm/parameters/show_notch 2>/dev/null; true'
+ExecStart=/usr/bin/bash -c 'dmesg -n 1 >/dev/null 2>&1; echo 1 >/sys/module/hid_apple/parameters/fnmode 2>/dev/null; echo 1 >/sys/module/appledrm/parameters/show_notch 2>/dev/null; true'
 
 [Install]
 WantedBy=multi-user.target

--- a/configs/usb/rootfs/omarchy-mac-esp.sh
+++ b/configs/usb/rootfs/omarchy-mac-esp.sh
@@ -72,7 +72,7 @@ write_piggyback_esp_grub() {
   cat >"$esp_mnt/grub/custom.cfg" <<EOF
 menuentry 'Omarchy Mac (new root $root_uuid)' {
   search --no-floppy --file /omarchy-mac-root --set=root
-  linux /EFI/omarchy/vmlinuz root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
+  linux /EFI/omarchy/vmlinuz root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3 quiet splash
   initrd /EFI/omarchy/initramfs.img
 }
 EOF
@@ -105,7 +105,7 @@ set default=0
 search --no-floppy --file /omarchy-mac-root --set=root
 
 menuentry 'Omarchy Mac' {
-  linux /EFI/omarchy/vmlinuz root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
+  linux /EFI/omarchy/vmlinuz root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3 quiet splash
   initrd /EFI/omarchy/initramfs.img
 }
 EOF

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -243,30 +243,39 @@ require_graphical_payload() {
     || fail "no Hyprland/omarchy wayland session in this payload — rebuild with --usb --rootfs"
 }
 
+# Ask before dd. A gum prompt after 30 minutes of copy dies if the lid
+# closes or the TTY goes away (Input/output error).
+ask_desktop_user() {
+  local pass2 reserved='^(root|bin|daemon|nobody|dbus|alpm|git|avahi|polkitd|sddm|uuidd)$'
+  if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
+    desktop_user=dryrun
+    desktop_pass=dryrun
+    return 0
+  fi
+  desktop_user=$(gum input --placeholder "username" --header "Desktop user (not root). Asked now so you can walk away during the copy.")
+  [[ -n $desktop_user ]] || fail "cancelled"
+  [[ $desktop_user =~ ^[a-z_][a-z0-9_-]*$ ]] || fail "invalid username"
+  [[ $desktop_user =~ $reserved ]] && fail "username $desktop_user is reserved"
+  desktop_pass=$(gum input --password --placeholder "password" --header "Password for $desktop_user")
+  [[ -n $desktop_pass ]] || fail "cancelled"
+  pass2=$(gum input --password --placeholder "password" --header "Confirm password")
+  [[ $desktop_pass == "$pass2" ]] || fail "passwords do not match"
+}
+
 # Live USB stays tty autologin. Installed roots get a user, SDDM, and
 # graphical.target. Mount @home before useradd so /home isn't on @.
 personalize_graphical_session() {
   local root_mnt=$1 root_part=$2
-  local user pass pass2 home_mounted=0 session
-  local reserved='^(root|bin|daemon|nobody|dbus|alpm|git|avahi|polkitd|sddm|uuidd)$'
+  local user=$desktop_user pass=$desktop_pass home_mounted=0 session
 
   require_graphical_payload "$root_mnt"
   session=$(basename "$(wayland_session_path "$root_mnt")")
+  [[ -n $user && -n $pass ]] || fail "desktop user was not collected before copy"
 
   if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
-    printf 'dry-run: useradd + enable sddm + graphical.target\n'
+    printf 'dry-run: useradd %s + enable sddm + graphical.target\n' "$user"
     return 0
   fi
-
-  user=$(gum input --placeholder "username" --header "Desktop user (not root)")
-  [[ -n $user ]] || fail "cancelled"
-  [[ $user =~ ^[a-z_][a-z0-9_-]*$ ]] || fail "invalid username"
-  [[ $user =~ $reserved ]] && fail "username $user is reserved"
-
-  pass=$(gum input --password --placeholder "password" --header "Password for $user")
-  [[ -n $pass ]] || fail "cancelled"
-  pass2=$(gum input --password --placeholder "password" --header "Confirm password")
-  [[ $pass == "$pass2" ]] || fail "passwords do not match"
 
   mkdir -p "$root_mnt/home"
   if ! findmnt "$root_mnt/home" >/dev/null; then
@@ -316,6 +325,7 @@ install_persistent_root() {
   command -v grub-mkstandalone >/dev/null || fail "grub-mkstandalone not found — rebuild with --usb --rootfs (grub)"
   [[ -f $SHARE/grub-embed-install.cfg ]] || fail "missing $SHARE/grub-embed-install.cfg — rebuild the live USB"
   require_graphical_payload
+  ask_desktop_user
 
   payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
   min_bytes=$(( ESP_MIB * 1024 * 1024 + payload_bytes + 64 * 1024 * 1024 ))
@@ -397,10 +407,16 @@ EOF
     live_esp_mounted_by_us=1
   fi
   [[ -f $live_esp_mnt/vmlinuz-linux-asahi ]] || fail "no vmlinuz-linux-asahi on the live ESP"
-  [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]] || fail "no initramfs-linux-asahi.img on the live ESP"
   cp "$live_esp_mnt/vmlinuz-linux-asahi" "$esp_mnt/vmlinuz-linux-asahi"
-  # Unique name: NVMe ESP also has initramfs-linux-asahi.img (LUKS).
-  cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-omarchy-usb-root.img"
+  # Live ISO ESP has initramfs-linux-asahi.img; a wipe-installed USB has
+  # only initramfs-omarchy-usb-root.img. Unique dest name vs NVMe LUKS.
+  if [[ -f $live_esp_mnt/initramfs-linux-asahi.img ]]; then
+    cp "$live_esp_mnt/initramfs-linux-asahi.img" "$esp_mnt/initramfs-omarchy-usb-root.img"
+  elif [[ -f $live_esp_mnt/initramfs-omarchy-usb-root.img ]]; then
+    cp "$live_esp_mnt/initramfs-omarchy-usb-root.img" "$esp_mnt/initramfs-omarchy-usb-root.img"
+  else
+    fail "no install initramfs on $source_esp (need initramfs-linux-asahi.img or initramfs-omarchy-usb-root.img)"
+  fi
   if (( live_esp_mounted_by_us == 1 )); then
     umount "$live_esp_mnt"
     rmdir "$live_esp_mnt"
@@ -520,6 +536,7 @@ install_into_free_space() {
 
   command -v parted >/dev/null || fail "parted not found"
   require_graphical_payload
+  ask_desktop_user
 
   payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
   min_bytes=$(( payload_bytes + 64 * 1024 * 1024 ))

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -262,6 +262,51 @@ ask_desktop_user() {
   [[ $desktop_pass == "$pass2" ]] || fail "passwords do not match"
 }
 
+# Same default as install/user/theme.sh. Seed at install so the first
+# frame is Tokyo Night even if first-run is slow. Failure is non-fatal:
+# omarchy-provision-first-run retries on login.
+seed_tokyo_night() {
+  local root_mnt=$1 user=$2
+  local bind
+  local -a bound=()
+
+  if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
+    printf 'dry-run: default theme Tokyo Night for %s\n' "$user"
+    return 0
+  fi
+  [[ -d $root_mnt/usr/share/omarchy/themes/tokyo-night ]] || return 0
+  [[ -x $root_mnt/usr/bin/omarchy-theme-set ]] || return 0
+
+  for bind in proc sys dev tmp; do
+    mkdir -p "$root_mnt/$bind"
+    if ! findmnt "$root_mnt/$bind" >/dev/null; then
+      if [[ $bind == tmp ]]; then
+        mount -t tmpfs tmpfs "$root_mnt/tmp"
+      else
+        mount --bind "/$bind" "$root_mnt/$bind"
+      fi
+      bound+=("$root_mnt/$bind")
+    fi
+  done
+
+  if chroot "$root_mnt" runuser -u "$user" -- env \
+      HOME=/home/"$user" USER="$user" LOGNAME="$user" \
+      OMARCHY_PATH=/usr/share/omarchy \
+      OMARCHY_SETUP_CONTEXT=iso-chroot \
+      OMARCHY_THEME_HEADLESS=1 \
+      omarchy-theme-set "Tokyo Night"
+  then
+    printf '==> default theme Tokyo Night for %s\n' "$user"
+  else
+    printf '==> Tokyo Night seed failed for %s; first login will retry\n' "$user"
+  fi
+
+  for bind in "${bound[@]}"; do
+    umount "$bind" 2>/dev/null || umount -l "$bind" 2>/dev/null || true
+  done
+  return 0
+}
+
 # Live USB stays tty autologin. Installed roots get a user, SDDM, and
 # graphical.target. Mount @home before useradd so /home isn't on @.
 personalize_graphical_session() {
@@ -285,6 +330,7 @@ personalize_graphical_session() {
   useradd --root "$root_mnt" -m -s /bin/bash \
     -G wheel,video,audio,input,render "$user"
   printf '%s:%s\n' "$user" "$pass" | chpasswd --root "$root_mnt"
+  seed_tokyo_night "$root_mnt" "$user"
   if (( home_mounted == 1 )); then
     umount "$root_mnt/home"
   fi
@@ -433,7 +479,7 @@ set default=0
 search --no-floppy --file /omarchy-usb-install --set=root
 
 menuentry 'Omarchy Mac (USB root)' {
-  linux /vmlinuz-linux-asahi root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3
+  linux /vmlinuz-linux-asahi root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3 quiet splash
   initrd /initramfs-omarchy-usb-root.img
 }
 EOF
@@ -702,6 +748,151 @@ EOF
   lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
 }
 
+# Replace the filesystem on an existing OMARCHYROOT. No mkpart, no mklabel,
+# no wipefs of the disk. The 46G NVMe hole (p7) is this path: the GPT gap
+# is already a partition, so free-space install would find nothing.
+install_over_existing_root() {
+  local name model extra size
+  local candidates=()
+  local source_esp esp_part root_part root_mnt
+  local root_uuid esp_uuid payload_bytes payload_mnt
+  local before_apple after_apple backup m esp_mode
+
+  command -v parted >/dev/null || fail "parted not found"
+  require_graphical_payload
+  ask_desktop_user
+
+  payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
+  source_esp=$(esp_partition_on "$live_disk" || true)
+  [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
+
+  while read -r name model; do
+    [[ $name == "$live_disk" ]] && continue
+    existing_esp_on "$name" >/dev/null || continue
+    root_part=$(existing_omarchy_root_on "$name" || true)
+    [[ -n $root_part ]] || continue
+    [[ $root_part == "$live_partition" ]] && continue
+    bytes=$(lsblk -dn -b -o SIZE "$root_part")
+    (( bytes >= payload_bytes + 64 * 1024 * 1024 )) || continue
+    size=$(lsblk -dn -o SIZE "$root_part")
+    extra=""
+    disk_has_apple_partitions "$name" && extra=" (keeps APFS)"
+    disk_is_nvme "$name" && extra="${extra} nvme"
+    candidates+=("$name  $root_part $size  ${model:-disk}${extra}")
+  done < <(lsblk -dn -o NAME,MODEL)
+
+  (( ${#candidates[@]} > 0 )) || fail "no existing OMARCHYROOT is large enough (need payload + 64MiB). Install into free space first, or pick a bigger partition."
+
+  choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Replace which existing OMARCHYROOT? Partition table stays.")
+  [[ -n $choice ]] || fail "cancelled"
+  target_name=${choice%% *}
+  target_dev=/dev/$target_name
+  esp_part=$(existing_esp_on "$target_name") || fail "$target_dev has no ESP"
+  root_part=$(existing_omarchy_root_on "$target_name") || fail "$target_dev has no OMARCHYROOT"
+  [[ $root_part == "$live_partition" ]] && fail "refusing to overwrite the live payload"
+  size=$(lsblk -dn -o SIZE "$root_part")
+
+  printf '==> selected %s on %s (%s)\n' "$root_part" "$target_dev" "$size"
+  printf '==> confirm (arrow keys, then enter)\n'
+  gum confirm \
+    "REPLACE $root_part ($size) on $target_dev. APFS/iBoot/Recovery, other partitions, and the GPT stay. No mklabel, no mkpart, no LUKS. Continue?" \
+    || fail "cancelled"
+
+  if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
+    printf 'dry-run: dd %s -> %s then btrfstune -u (no mkpart, no mklabel)\n' \
+      "$live_partition" "$root_part"
+    printf 'dry-run: would NOT mklabel, mkpart, or wipefs\n'
+    return 0
+  fi
+
+  if (( running_from_this_live_usb != 1 )); then
+    payload_mnt=$(findmnt -n -o TARGET "$live_partition" || true)
+    if [[ -n $payload_mnt ]]; then
+      umount "$payload_mnt" || fail "could not unmount $payload_mnt before dd"
+    fi
+  fi
+
+  backup=$(mktemp /tmp/omarchy-gpt-${target_name}.XXXXXX)
+  if command -v sfdisk >/dev/null; then
+    sfdisk --dump "$target_dev" >"$backup"
+    printf '==> GPT dump saved at %s\n' "$backup"
+  fi
+  before_apple=$(apple_partition_snapshot "$target_dev")
+
+  for _ in 1 2 3 4 5 6; do
+    m=$(findmnt -n -o TARGET "$root_part" || true)
+    [[ -z $m ]] && break
+    umount "$m" || umount -l "$m" || true
+    sleep 0.5
+  done
+  findmnt -n "$root_part" >/dev/null && fail "$root_part still mounted; cannot dd"
+
+  printf '==> copying payload %s -> %s\n' "$live_partition" "$root_part"
+  dd if="$live_partition" of="$root_part" bs=4M status=progress conv=fsync oflag=sync
+  sync
+  partprobe "$target_dev" 2>/dev/null || true
+  command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
+
+  after_apple=$(apple_partition_snapshot "$target_dev")
+  if [[ $before_apple != "$after_apple" ]]; then
+    printf 'error: Apple partition types changed — aborting\n' >&2
+    printf 'before:\n%s\nafter:\n%s\n' "$before_apple" "$after_apple" >&2
+    exit 1
+  fi
+
+  for _ in 1 2 3 4 5 6; do
+    m=$(findmnt -n -o TARGET "$root_part" || true)
+    [[ -z $m ]] && break
+    umount "$m" || umount -l "$m" || true
+    sleep 0.5
+  done
+  findmnt -n "$root_part" >/dev/null && fail "$root_part still mounted; cannot btrfstune"
+  if command -v btrfs >/dev/null; then
+    btrfs device scan --forget "$root_part" || true
+  fi
+  btrfstune -f -u "$root_part"
+
+  root_mnt=$(mktemp -d)
+  mount -o subvol=@ "$root_part" "$root_mnt"
+  btrfs filesystem resize max "$root_mnt"
+  btrfs filesystem label "$root_mnt" OMARCHYROOT
+  root_uuid=$(blkid -s UUID -o value "$root_part")
+  [[ -n $root_uuid ]] || fail "no UUID on $root_part"
+
+  printf 'UUID=%s / btrfs subvol=@,compress=zstd:1 0 0\n' "$root_uuid" >"$root_mnt/etc/fstab"
+  printf 'UUID=%s /home btrfs subvol=@home,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
+  printf 'UUID=%s /var/log btrfs subvol=@log,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
+  printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
+  cat >"$root_mnt/etc/issue" <<'EOF'
+Omarchy Mac (installed). SDDM autologin.
+Wi-Fi: nmtui Rescan, then Activate if the session has no network.
+EOF
+  rm -f "$root_mnt/omarchy-mac-overlay-write"
+  : >"$root_mnt/etc/machine-id"
+
+  esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp")
+
+  esp_uuid=$(blkid -s UUID -o value "$esp_part")
+  printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"
+
+  personalize_graphical_session "$root_mnt" "$root_part"
+
+  sync
+  umount "$root_mnt"
+  rmdir "$root_mnt" 2>/dev/null || true
+
+  printf '==> done. Did not mklabel or mkpart %s. Replaced %s UUID=%s\n' \
+    "$target_dev" "$root_part" "$root_uuid"
+  if [[ $esp_mode == own ]]; then
+    printf '    System ESP %s: wrote BOOTAA64.EFI (m1n1/vendorfw/asahi unchanged). GPT dump: %s\n' \
+      "$esp_part" "$backup"
+  else
+    printf '    Boot via existing ESP %s (custom.cfg). GPT dump: %s\n' \
+      "$esp_part" "$backup"
+  fi
+  lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
+}
+
 # Re-use an OMARCHYROOT already on the disk. Writes GRUB only: no mkpart, no dd.
 install_grub_for_existing_root() {
   local name model extra
@@ -753,6 +944,7 @@ install_grub_for_existing_root() {
 
 action=$(gum choose --header "Omarchy Mac live USB" \
   "Install into free space (keeps existing partitions)" \
+  "Replace an existing OMARCHYROOT (no new partition)" \
   "Install GRUB for an existing OMARCHYROOT (no new partition)" \
   "Install to a blank USB (wipes the whole disk)" \
   "Clone this live USB onto another stick")
@@ -760,6 +952,7 @@ action=$(gum choose --header "Omarchy Mac live USB" \
 
 case $action in
   "Install into free space"*) install_into_free_space ;;
+  "Replace an existing OMARCHYROOT"*) install_over_existing_root ;;
   "Install GRUB for an existing"*) install_grub_for_existing_root ;;
   "Install to a blank USB"*) install_persistent_root ;;
   Clone*) clone_live_usb ;;

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -221,6 +221,70 @@ clone_live_usb() {
   lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
 }
 
+# Live USB stays tty autologin. Installed roots get a user, SDDM, and
+# graphical.target. Mount @home before useradd so /home isn't on @.
+personalize_graphical_session() {
+  local root_mnt=$1 root_part=$2
+  local user pass pass2 home_mounted=0
+  local reserved='^(root|bin|daemon|nobody|dbus|alpm|git|avahi|polkitd|sddm|uuidd)$'
+
+  [[ -x $root_mnt/usr/bin/sddm ]] \
+    || fail "sddm not in this payload — rebuild with --usb --rootfs"
+  [[ -f $root_mnt/usr/share/wayland-sessions/omarchy.desktop ]] \
+    || fail "omarchy.desktop session missing — rebuild with --usb --rootfs"
+
+  if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
+    printf 'dry-run: useradd + enable sddm + graphical.target\n'
+    return 0
+  fi
+
+  user=$(gum input --placeholder "username" --header "Desktop user (not root)")
+  [[ -n $user ]] || fail "cancelled"
+  [[ $user =~ ^[a-z_][a-z0-9_-]*$ ]] || fail "invalid username"
+  [[ $user =~ $reserved ]] && fail "username $user is reserved"
+
+  pass=$(gum input --password --placeholder "password" --header "Password for $user")
+  [[ -n $pass ]] || fail "cancelled"
+  pass2=$(gum input --password --placeholder "password" --header "Confirm password")
+  [[ $pass == "$pass2" ]] || fail "passwords do not match"
+
+  mkdir -p "$root_mnt/home"
+  if ! findmnt "$root_mnt/home" >/dev/null; then
+    mount -o subvol=@home "$root_part" "$root_mnt/home"
+    home_mounted=1
+  fi
+  useradd --root "$root_mnt" -m -s /bin/bash \
+    -G wheel,video,audio,input,render "$user"
+  printf '%s:%s\n' "$user" "$pass" | chpasswd --root "$root_mnt"
+  if (( home_mounted == 1 )); then
+    umount "$root_mnt/home"
+  fi
+
+  rm -f "$root_mnt/etc/systemd/system/getty@tty1.service.d/autologin.conf"
+  rmdir "$root_mnt/etc/systemd/system/getty@tty1.service.d" 2>/dev/null || true
+
+  mkdir -p "$root_mnt/etc/sddm.conf.d"
+  cat >"$root_mnt/etc/sddm.conf.d/autologin.conf" <<EOF
+[Autologin]
+User=$user
+Session=omarchy.desktop
+EOF
+  if [[ -f $root_mnt/etc/pam.d/sddm ]]; then
+    sed -i '/-auth.*pam_gnome_keyring\.so/d' "$root_mnt/etc/pam.d/sddm"
+    sed -i '/-password.*pam_gnome_keyring\.so/d' "$root_mnt/etc/pam.d/sddm"
+  fi
+  install -d -m750 "$root_mnt/etc/sudoers.d"
+  printf '%%wheel ALL=(ALL:ALL) ALL\n' >"$root_mnt/etc/sudoers.d/wheel"
+  chmod 440 "$root_mnt/etc/sudoers.d/wheel"
+
+  systemctl --root="$root_mnt" disable omarchy-mac-usb-ready.service 2>/dev/null || true
+  systemctl --root="$root_mnt" enable sddm.service
+  systemctl --root="$root_mnt" set-default graphical.target
+  systemctl --root="$root_mnt" mask NetworkManager-wait-online.service 2>/dev/null || true
+
+  printf '==> desktop user %s, SDDM autologin, graphical.target\n' "$user"
+}
+
 install_persistent_root() {
   local payload_bytes min_bytes source_esp esp_part root_part
   local root_mnt esp_mnt live_esp_mnt
@@ -293,11 +357,12 @@ install_persistent_root() {
   printf 'UUID=%s /var/log btrfs subvol=@log,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
   printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
   cat >"$root_mnt/etc/issue" <<'EOF'
-Omarchy Mac USB root (not live, not the desktop).
-Wi-Fi: nmtui Rescan, then Activate.
+Omarchy Mac (installed). SDDM autologin.
+Wi-Fi: nmtui Rescan, then Activate if the session has no network.
 EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
+  personalize_graphical_session "$root_mnt" "$root_part"
 
   work=$(mktemp -d)
   esp_mnt=$(mktemp -d)
@@ -568,11 +633,12 @@ install_into_free_space() {
   printf 'UUID=%s /var/log btrfs subvol=@log,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
   printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
   cat >"$root_mnt/etc/issue" <<'EOF'
-Omarchy Mac USB root (not live, not the desktop).
-Wi-Fi: nmtui Rescan, then Activate.
+Omarchy Mac (installed). SDDM autologin.
+Wi-Fi: nmtui Rescan, then Activate if the session has no network.
 EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
+  personalize_graphical_session "$root_mnt" "$root_part"
 
   esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp")
 

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -6,6 +6,33 @@ set -euo pipefail
 
 fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
 
+# Wall time of the copy/personalize, not the gum questions.
+install_start=0
+mark_install_start() { install_start=$EPOCHSECONDS; }
+
+format_duration() {
+  local total=$1 minutes seconds
+  minutes=$(( total / 60 ))
+  seconds=$(( total % 60 ))
+  if (( minutes > 0 )); then
+    printf '%dm %02ds' "$minutes" "$seconds"
+  else
+    printf '%ds' "$seconds"
+  fi
+}
+
+offer_reboot_after_install() {
+  local elapsed
+  (( install_start > 0 )) || return 0
+  elapsed=$(( EPOCHSECONDS - install_start ))
+  printf '==> finished in %s\n' "$(format_duration "$elapsed")"
+  [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]] && return 0
+  if gum confirm --affirmative "Yes, reboot" --negative "Stay here" "Reboot this machine?"; then
+    printf '==> rebooting\n'
+    systemctl reboot
+  fi
+}
+
 GPT_BACKUP_BYTES=$((34 * 512))
 ESP_MIB=512
 SHARE=/usr/local/share/omarchy-mac-iso
@@ -183,6 +210,7 @@ clone_live_usb() {
     "This will DESTROY every partition on $target_dev (${choice#*  }). $copy_bytes bytes from $source_dev are copied onto it. Continue?" \
     || fail "cancelled"
 
+  mark_install_start
   unmount_disk "$target_dev"
   if (( running_from_this_live_usb == 1 )); then
     unmount_disk "$source_dev" 1
@@ -252,13 +280,13 @@ ask_desktop_user() {
     desktop_pass=dryrun
     return 0
   fi
-  desktop_user=$(gum input --placeholder "username" --header "Desktop user (not root). Asked now so you can walk away during the copy.")
+  desktop_user=$(gum input --placeholder "Alphanumeric without spaces (like dhh)" --header "Username for the installed desktop")
   [[ -n $desktop_user ]] || fail "cancelled"
   [[ $desktop_user =~ ^[a-z_][a-z0-9_-]*$ ]] || fail "invalid username"
   [[ $desktop_user =~ $reserved ]] && fail "username $desktop_user is reserved"
-  desktop_pass=$(gum input --password --placeholder "password" --header "Password for $desktop_user")
+  desktop_pass=$(gum input --password --placeholder "Used for the desktop user" --header "Password")
   [[ -n $desktop_pass ]] || fail "cancelled"
-  pass2=$(gum input --password --placeholder "password" --header "Confirm password")
+  pass2=$(gum input --password --placeholder "Must match the password you just typed" --header "Confirm password")
   [[ $desktop_pass == "$pass2" ]] || fail "passwords do not match"
 }
 
@@ -382,6 +410,7 @@ install_persistent_root() {
     || fail "cancelled"
   printf '==> confirmed\n'
 
+  mark_install_start
   source_esp=$(esp_partition_on "$live_disk" || true)
   [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
 
@@ -435,7 +464,6 @@ install_persistent_root() {
   printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
   cat >"$root_mnt/etc/issue" <<'EOF'
 Omarchy Mac (installed). SDDM autologin.
-Wi-Fi: nmtui Rescan, then Activate if the session has no network.
 EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
@@ -636,6 +664,7 @@ install_into_free_space() {
     return 0
   fi
 
+  mark_install_start
   source_esp=$(esp_partition_on "$live_disk" || true)
   [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
   esp_part=$(existing_esp_on "$target_name" || true)
@@ -720,7 +749,6 @@ install_into_free_space() {
   printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
   cat >"$root_mnt/etc/issue" <<'EOF'
 Omarchy Mac (installed). SDDM autologin.
-Wi-Fi: nmtui Rescan, then Activate if the session has no network.
 EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
@@ -748,11 +776,27 @@ EOF
   lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
 }
 
+# One gum-choose row per existing Omarchy root. First field is the
+# partition node so two roots (NVMe hole vs USB stick) cannot be confused.
+existing_root_row() {
+  local root_part=$1
+  local disk size model where
+  disk=$(lsblk -no PKNAME "$root_part")
+  size=$(lsblk -dn -o SIZE "$root_part")
+  model=$(lsblk -dn -o MODEL "/dev/$disk" | tr -s ' ')
+  if disk_is_nvme "$disk"; then
+    where="internal NVMe — other partitions stay"
+  else
+    where="USB stick — ${model:-usb}"
+  fi
+  printf '%s  %s  %s\n' "$root_part" "$size" "$where"
+}
+
 # Replace the filesystem on an existing OMARCHYROOT. No mkpart, no mklabel,
 # no wipefs of the disk. The 46G NVMe hole (p7) is this path: the GPT gap
 # is already a partition, so free-space install would find nothing.
 install_over_existing_root() {
-  local name model extra size
+  local name size
   local candidates=()
   local source_esp esp_part root_part root_mnt
   local root_uuid esp_uuid payload_bytes payload_mnt
@@ -760,13 +804,12 @@ install_over_existing_root() {
 
   command -v parted >/dev/null || fail "parted not found"
   require_graphical_payload
-  ask_desktop_user
 
   payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
   source_esp=$(esp_partition_on "$live_disk" || true)
   [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
 
-  while read -r name model; do
+  while read -r name; do
     [[ $name == "$live_disk" ]] && continue
     existing_esp_on "$name" >/dev/null || continue
     root_part=$(existing_omarchy_root_on "$name" || true)
@@ -774,28 +817,27 @@ install_over_existing_root() {
     [[ $root_part == "$live_partition" ]] && continue
     bytes=$(lsblk -dn -b -o SIZE "$root_part")
     (( bytes >= payload_bytes + 64 * 1024 * 1024 )) || continue
-    size=$(lsblk -dn -o SIZE "$root_part")
-    extra=""
-    disk_has_apple_partitions "$name" && extra=" (keeps APFS)"
-    disk_is_nvme "$name" && extra="${extra} nvme"
-    candidates+=("$name  $root_part $size  ${model:-disk}${extra}")
-  done < <(lsblk -dn -o NAME,MODEL)
+    candidates+=("$(existing_root_row "$root_part")")
+  done < <(lsblk -dn -o NAME)
 
   (( ${#candidates[@]} > 0 )) || fail "no existing OMARCHYROOT is large enough (need payload + 64MiB). Install into free space first, or pick a bigger partition."
 
-  choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Replace which existing OMARCHYROOT? Partition table stays.")
+  choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Which Omarchy root partition should be replaced? Not the ESP.")
   [[ -n $choice ]] || fail "cancelled"
-  target_name=${choice%% *}
+  root_part=${choice%% *}
+  [[ $root_part == /dev/* ]] || fail "could not parse partition from selection"
+  target_name=$(lsblk -no PKNAME "$root_part")
+  [[ -n $target_name ]] || fail "could not find the disk for $root_part"
   target_dev=/dev/$target_name
   esp_part=$(existing_esp_on "$target_name") || fail "$target_dev has no ESP"
-  root_part=$(existing_omarchy_root_on "$target_name") || fail "$target_dev has no OMARCHYROOT"
   [[ $root_part == "$live_partition" ]] && fail "refusing to overwrite the live payload"
   size=$(lsblk -dn -o SIZE "$root_part")
 
   printf '==> selected %s on %s (%s)\n' "$root_part" "$target_dev" "$size"
+  ask_desktop_user
   printf '==> confirm (arrow keys, then enter)\n'
   gum confirm \
-    "REPLACE $root_part ($size) on $target_dev. APFS/iBoot/Recovery, other partitions, and the GPT stay. No mklabel, no mkpart, no LUKS. Continue?" \
+    "Replace ONLY $root_part ($size) on $target_dev. Not the ESP. Other partitions stay. No mklabel, no mkpart, no LUKS. Continue?" \
     || fail "cancelled"
 
   if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
@@ -805,6 +847,7 @@ install_over_existing_root() {
     return 0
   fi
 
+  mark_install_start
   if (( running_from_this_live_usb != 1 )); then
     payload_mnt=$(findmnt -n -o TARGET "$live_partition" || true)
     if [[ -n $payload_mnt ]]; then
@@ -865,7 +908,6 @@ install_over_existing_root() {
   printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
   cat >"$root_mnt/etc/issue" <<'EOF'
 Omarchy Mac (installed). SDDM autologin.
-Wi-Fi: nmtui Rescan, then Activate if the session has no network.
 EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
@@ -903,24 +945,24 @@ install_grub_for_existing_root() {
   source_esp=$(esp_partition_on "$live_disk" || true)
   [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
 
-  while read -r name model; do
+  while read -r name; do
     [[ $name == "$live_disk" ]] && continue
     existing_esp_on "$name" >/dev/null || continue
-    existing_omarchy_root_on "$name" >/dev/null || continue
-    extra=""
-    disk_has_apple_partitions "$name" && extra=" (keeps APFS)"
-    disk_is_nvme "$name" && extra="${extra} nvme"
-    candidates+=("$name  OMARCHYROOT on ${model:-disk}${extra}")
-  done < <(lsblk -dn -o NAME,MODEL)
+    root_part=$(existing_omarchy_root_on "$name" || true)
+    [[ -n $root_part ]] || continue
+    candidates+=("$(existing_root_row "$root_part")")
+  done < <(lsblk -dn -o NAME)
 
   (( ${#candidates[@]} > 0 )) || fail "no disk has both an ESP and an OMARCHYROOT (install into free space first)"
 
-  choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Write GRUB for which existing OMARCHYROOT?")
+  choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Write GRUB for which Omarchy root? Filesystem stays.")
   [[ -n $choice ]] || fail "cancelled"
-  target_name=${choice%% *}
+  root_part=${choice%% *}
+  [[ $root_part == /dev/* ]] || fail "could not parse partition from selection"
+  target_name=$(lsblk -no PKNAME "$root_part")
+  [[ -n $target_name ]] || fail "could not find the disk for $root_part"
   target_dev=/dev/$target_name
   esp_part=$(existing_esp_on "$target_name") || fail "$target_dev has no ESP"
-  root_part=$(existing_omarchy_root_on "$target_name") || fail "$target_dev has no OMARCHYROOT"
   root_uuid=$(blkid -s UUID -o value "$root_part")
   [[ -n $root_uuid ]] || fail "no UUID on $root_part"
 
@@ -936,25 +978,36 @@ install_grub_for_existing_root() {
     return 0
   fi
 
+  mark_install_start
   esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp")
   printf '==> done. GRUB mode=%s ESP=%s root=%s UUID=%s\n' \
     "$esp_mode" "$esp_part" "$root_part" "$root_uuid"
   lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
 }
 
-action=$(gum choose --header "Omarchy Mac live USB" \
-  "Install into free space (keeps existing partitions)" \
-  "Replace an existing OMARCHYROOT (no new partition)" \
-  "Install GRUB for an existing OMARCHYROOT (no new partition)" \
-  "Install to a blank USB (wipes the whole disk)" \
+omarchy_path=${OMARCHY_PATH:-/usr/share/omarchy}
+if [[ -f $omarchy_path/logo.txt ]]; then
+  clear
+  printf '\033[32m'
+  cat "$omarchy_path/logo.txt"
+  printf '\033[0m\n'
+fi
+
+action=$(gum choose --header "How should this machine be installed?" \
+  "Install into free space (keeps macOS and existing partitions)" \
+  "Reinstall an existing Omarchy root (you pick the partition)" \
+  "Write GRUB for an existing Omarchy root (no copy)" \
+  "Wipe a USB stick and install (never NVMe, never APFS)" \
   "Clone this live USB onto another stick")
 [[ -n $action ]] || fail "cancelled"
 
 case $action in
   "Install into free space"*) install_into_free_space ;;
-  "Replace an existing OMARCHYROOT"*) install_over_existing_root ;;
-  "Install GRUB for an existing"*) install_grub_for_existing_root ;;
-  "Install to a blank USB"*) install_persistent_root ;;
+  "Reinstall an existing Omarchy root"*) install_over_existing_root ;;
+  "Write GRUB for an existing"*) install_grub_for_existing_root ;;
+  "Wipe a USB stick"*) install_persistent_root ;;
   Clone*) clone_live_usb ;;
   *) fail "unknown action" ;;
 esac
+
+offer_reboot_after_install

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -221,17 +221,37 @@ clone_live_usb() {
   lsblk -o NAME,SIZE,FSTYPE,LABEL,UUID "$target_dev"
 }
 
+# omarchy.desktop is shipped in /usr/local/share/wayland-sessions, not
+# /usr/share (hyprland.desktop lives there).
+wayland_session_path() {
+  local root=$1 f
+  for f in \
+    "$root/usr/local/share/wayland-sessions/omarchy.desktop" \
+    "$root/usr/share/wayland-sessions/omarchy.desktop" \
+    "$root/usr/share/wayland-sessions/hyprland-uwsm.desktop" \
+    "$root/usr/share/wayland-sessions/hyprland.desktop"; do
+    [[ -f $f ]] && { printf '%s\n' "$f"; return 0; }
+  done
+  return 1
+}
+
+require_graphical_payload() {
+  local root=${1:-}
+  [[ -x $root/usr/bin/sddm ]] \
+    || fail "sddm not in this payload — rebuild with --usb --rootfs"
+  wayland_session_path "$root" >/dev/null \
+    || fail "no Hyprland/omarchy wayland session in this payload — rebuild with --usb --rootfs"
+}
+
 # Live USB stays tty autologin. Installed roots get a user, SDDM, and
 # graphical.target. Mount @home before useradd so /home isn't on @.
 personalize_graphical_session() {
   local root_mnt=$1 root_part=$2
-  local user pass pass2 home_mounted=0
+  local user pass pass2 home_mounted=0 session
   local reserved='^(root|bin|daemon|nobody|dbus|alpm|git|avahi|polkitd|sddm|uuidd)$'
 
-  [[ -x $root_mnt/usr/bin/sddm ]] \
-    || fail "sddm not in this payload — rebuild with --usb --rootfs"
-  [[ -f $root_mnt/usr/share/wayland-sessions/omarchy.desktop ]] \
-    || fail "omarchy.desktop session missing — rebuild with --usb --rootfs"
+  require_graphical_payload "$root_mnt"
+  session=$(basename "$(wayland_session_path "$root_mnt")")
 
   if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
     printf 'dry-run: useradd + enable sddm + graphical.target\n'
@@ -267,7 +287,7 @@ personalize_graphical_session() {
   cat >"$root_mnt/etc/sddm.conf.d/autologin.conf" <<EOF
 [Autologin]
 User=$user
-Session=omarchy.desktop
+Session=$session
 EOF
   if [[ -f $root_mnt/etc/pam.d/sddm ]]; then
     sed -i '/-auth.*pam_gnome_keyring\.so/d' "$root_mnt/etc/pam.d/sddm"
@@ -295,6 +315,7 @@ install_persistent_root() {
   command -v mkfs.btrfs >/dev/null || fail "btrfs-progs not found"
   command -v grub-mkstandalone >/dev/null || fail "grub-mkstandalone not found — rebuild with --usb --rootfs (grub)"
   [[ -f $SHARE/grub-embed-install.cfg ]] || fail "missing $SHARE/grub-embed-install.cfg — rebuild the live USB"
+  require_graphical_payload
 
   payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
   min_bytes=$(( ESP_MIB * 1024 * 1024 + payload_bytes + 64 * 1024 * 1024 ))
@@ -362,7 +383,6 @@ Wi-Fi: nmtui Rescan, then Activate if the session has no network.
 EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
-  personalize_graphical_session "$root_mnt" "$root_part"
 
   work=$(mktemp -d)
   esp_mnt=$(mktemp -d)
@@ -414,6 +434,8 @@ EOF
 
   esp_uuid=$(blkid -s UUID -o value "$esp_part")
   printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"
+
+  personalize_graphical_session "$root_mnt" "$root_part"
 
   sync
   umount "$esp_mnt"
@@ -497,6 +519,7 @@ install_into_free_space() {
   local created_parts=()
 
   command -v parted >/dev/null || fail "parted not found"
+  require_graphical_payload
 
   payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
   min_bytes=$(( payload_bytes + 64 * 1024 * 1024 ))
@@ -638,12 +661,13 @@ Wi-Fi: nmtui Rescan, then Activate if the session has no network.
 EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
-  personalize_graphical_session "$root_mnt" "$root_part"
 
   esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp")
 
   esp_uuid=$(blkid -s UUID -o value "$esp_part")
   printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"
+
+  personalize_graphical_session "$root_mnt" "$root_part"
 
   sync
   umount "$root_mnt"

--- a/configs/usb/rootfs/omarchy-mac-live-welcome
+++ b/configs/usb/rootfs/omarchy-mac-live-welcome
@@ -11,14 +11,19 @@ command -v gum >/dev/null || exit 0
 # tty1 is also the kmsg console. printk overwrites gum.
 dmesg -n 1 2>/dev/null || true
 
-clear
+omarchy_path=${OMARCHY_PATH:-/usr/share/omarchy}
+if [[ -f $omarchy_path/logo.txt ]]; then
+  clear
+  printf '\033[32m'
+  cat "$omarchy_path/logo.txt"
+  printf '\033[0m\n'
+else
+  clear
+fi
+
 cat <<'EOF'
-
-  Omarchy Mac live USB
-
   This stick is the installer, not an installed desktop.
-  Wi-Fi:  nmtui  →  Rescan until SSIDs appear  →  Activate
-  Install never touches APFS; you pick the disk next.
+  Install never touches APFS. You pick which partition next.
 
   Arrow keys, then enter.
 
@@ -34,4 +39,4 @@ case $choice in
     ;;
 esac
 
-printf '\nWi-Fi:   nmtui\nInstall: omarchy-mac-install\n\n'
+printf '\nInstall: omarchy-mac-install\n\n'

--- a/configs/usb/rootfs/omarchy-mac-live-welcome
+++ b/configs/usb/rootfs/omarchy-mac-live-welcome
@@ -1,0 +1,37 @@
+#!/bin/bash
+# First login on the live USB (tty1 autologin root). Explain that this
+# stick is the installer and offer to start omarchy-mac-install.
+# Installed roots drop /omarchy-mac-overlay-write, so this is a no-op there.
+set -euo pipefail
+
+[[ -e /omarchy-mac-overlay-write ]] || exit 0
+[[ -t 0 && -t 1 ]] || exit 0
+command -v gum >/dev/null || exit 0
+
+# tty1 is also the kmsg console. printk overwrites gum.
+dmesg -n 1 2>/dev/null || true
+
+clear
+cat <<'EOF'
+
+  Omarchy Mac live USB
+
+  This stick is the installer, not an installed desktop.
+  Wi-Fi:  nmtui  →  Rescan until SSIDs appear  →  Activate
+  Install never touches APFS; you pick the disk next.
+
+  Arrow keys, then enter.
+
+EOF
+
+choice=$(gum choose --header "What next?" \
+  "Install Omarchy" \
+  "Open a shell") || true
+
+case $choice in
+  "Install Omarchy")
+    exec omarchy-mac-install
+    ;;
+esac
+
+printf '\nWi-Fi:   nmtui\nInstall: omarchy-mac-install\n\n'

--- a/configs/usb/rootfs/packages
+++ b/configs/usb/rootfs/packages
@@ -7,6 +7,12 @@ quickshell
 uwsm
 sddm
 xdg-desktop-portal-hyprland
+# SUPER+Return → omarchy-launch-terminal → xdg-terminal-exec.
+# omarchy-base uses foot; without both, the desktop has no terminal.
+foot
+xdg-terminal-exec
+# SUPER+Shift+Return → omarchy-launch-browser (chromium.desktop).
+chromium
 snapper
 plymouth
 gnome-keyring

--- a/configs/usb/rootfs/root-bash-profile
+++ b/configs/usb/rootfs/root-bash-profile
@@ -1,0 +1,8 @@
+# Live USB tty1 autologin. Installed roots delete /omarchy-mac-overlay-write
+# and drop this getty, so a TTY login there does not re-enter the installer.
+if [[ -e /omarchy-mac-overlay-write && -t 0 ]]; then
+  tty=$(tty 2>/dev/null || true)
+  if [[ $tty == /dev/tty1 ]]; then
+    /usr/local/sbin/omarchy-mac-live-welcome
+  fi
+fi

--- a/test/unit
+++ b/test/unit
@@ -96,6 +96,16 @@ check "install script rewrites clone btrfs UUID" grep -q 'btrfstune -f -u' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install script offers persistent root install" grep -q 'Install to a blank USB' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "installed root enables sddm" grep -q 'enable sddm.service' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "installed root uses graphical.target" grep -q 'set-default graphical.target' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "installed root creates a desktop user on @home" grep -q 'subvol=@home' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "installed root drops getty autologin" grep -q 'autologin.conf' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "live rootfs stays multi-user.target" grep -q 'set-default multi-user.target' \
+  "${repo_root}/builder/build-rootfs.sh"
 check "install script offers free-space install" grep -q 'Install into free space' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "free-space install does not wipefs" \

--- a/test/unit
+++ b/test/unit
@@ -103,6 +103,11 @@ check "session file is looked up in usr/local/share" grep -q \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "graphical payload is required before wipefs" \
   bash -c 'awk "/^install_persistent_root\\(\\)/,/wipefs/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q require_graphical_payload'
+check "desktop user is asked before the payload copy" \
+  bash -c 'awk "/^install_persistent_root\\(\\)/,/copying payload/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q ask_desktop_user'
+check "install initrd can come from a wipe-installed USB ESP" grep -q \
+  'initramfs-omarchy-usb-root.img ]]; then' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "installed root uses graphical.target" grep -q 'set-default graphical.target' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "installed root creates a desktop user on @home" grep -q 'subvol=@home' \

--- a/test/unit
+++ b/test/unit
@@ -64,6 +64,12 @@ check "rootfs pacstraps mesa and gum" grep -q ' mesa ' \
   "${repo_root}/builder/build-rootfs.sh"
 check "rootfs extra packages include hyprland" grep -qx hyprland \
   "${repo_root}/configs/usb/rootfs/packages"
+check "rootfs extra packages include foot" grep -qx foot \
+  "${repo_root}/configs/usb/rootfs/packages"
+check "rootfs extra packages include xdg-terminal-exec" grep -qx xdg-terminal-exec \
+  "${repo_root}/configs/usb/rootfs/packages"
+check "rootfs extra packages include chromium" grep -qx chromium \
+  "${repo_root}/configs/usb/rootfs/packages"
 check "rootfs extra packages omit linux-asahi" \
   bash -c '! grep -qx linux-asahi "'"${repo_root}"'/configs/usb/rootfs/packages"'
 check "rootfs extra packages omit asahi-scripts" \
@@ -112,6 +118,12 @@ check "installed root uses graphical.target" grep -q 'set-default graphical.targ
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "installed root creates a desktop user on @home" grep -q 'subvol=@home' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "installed root seeds Tokyo Night" grep -q 'omarchy-theme-set "Tokyo Night"' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "installed USB GRUB uses quiet splash" grep -q 'loglevel=3 quiet splash' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "system ESP GRUB uses quiet splash" grep -q 'loglevel=3 quiet splash' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
 check "installed root drops getty autologin" grep -q 'autologin.conf' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "live rootfs stays multi-user.target" grep -q 'set-default multi-user.target' \
@@ -120,6 +132,18 @@ check "install script offers free-space install" grep -q 'Install into free spac
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "free-space install does not wipefs" \
   bash -c 'awk "/^install_into_free_space\\(\\)/,/^action=/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -qv wipefs'
+check "install script offers replace existing OMARCHYROOT" grep -q \
+  'Replace an existing OMARCHYROOT' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "replace existing root does not mkpart or mklabel" \
+  bash -c '! awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -qE "wipefs -a|mklabel gpt|[[:space:]]mkpart root"'
+check "replace existing root asks the desktop user before dd" \
+  bash -c 'awk "/^install_over_existing_root\\(\\)/,/copying payload/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q ask_desktop_user'
+check "replace existing root refuses the live payload" grep -q \
+  'refusing to overwrite the live payload' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "replace existing root checks Apple types after dd" \
+  bash -c 'awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q before_apple'
 check "sh -n omarchy-mac-disk.sh" bash -n \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-disk.sh"
 check "partition loopback tests" "${repo_root}/test/partition"
@@ -127,6 +151,18 @@ check "install script labels the installed root OMARCHYROOT" grep -q OMARCHYROOT
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "sh -n omarchy-mac-install" bash -n \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "sh -n omarchy-mac-live-welcome" bash -n \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
+check "live welcome only runs on the overlay" grep -q omarchy-mac-overlay-write \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
+check "live welcome offers Install Omarchy" grep -q 'Install Omarchy' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
+check "live welcome execs the installer" grep -q 'exec omarchy-mac-install' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
+check "rootfs installs live welcome on tty1 autologin" grep -q omarchy-mac-live-welcome \
+  "${repo_root}/builder/build-rootfs.sh"
+check "root bash_profile only runs welcome on tty1" grep -q '/dev/tty1' \
+  "${repo_root}/configs/usb/rootfs/root-bash-profile"
 check "usb grub embed loads /grub/grub.cfg" grep -q 'configfile /grub/grub.cfg' \
   "${repo_root}/configs/usb/grub-embed.cfg"
 check "live GRUB searches omarchy-usb-live not NVMe grub.cfg" grep -q /omarchy-usb-live \

--- a/test/unit
+++ b/test/unit
@@ -135,6 +135,9 @@ check "install GRUB searches omarchy-usb-install" grep -q /omarchy-usb-install \
   "${repo_root}/configs/usb/grub-embed-install.cfg"
 check "install initramfs waits for USB root" grep -q OMARCHYROOT \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-wait"
+check "usb-wait does not succeed on OMARCHYROOT when UUID is set" grep -q \
+  'if \[ -z "$uuid" \] && \[ -e /dev/disk/by-label/OMARCHYROOT \]' \
+  "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-wait"
 check "install initramfs lists dwc3_apple" grep -q dwc3_apple \
   "${repo_root}/configs/usb-initcpio/mkinitcpio-install.conf"
 check "sh -n omarchy-usb-wait" sh -n \

--- a/test/unit
+++ b/test/unit
@@ -145,7 +145,7 @@ check "usb image embeds grub-embed.cfg" grep -q grub-embed.cfg \
   "${repo_root}/builder/build-usb-image.sh"
 check "usb image builds install initramfs" grep -q initramfs-linux-asahi.img \
   "${repo_root}/builder/build-usb-image.sh"
-check "install copies initramfs from live ESP" grep -q 'initramfs-linux-asahi.img on the live ESP' \
+check "install copies initramfs from live ESP" grep -q 'no install initramfs on' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install initrd name is unique vs NVMe" grep -q initramfs-omarchy-usb-root.img \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"

--- a/test/unit
+++ b/test/unit
@@ -100,7 +100,7 @@ check "install script keeps overlay lowerdir mounted" grep -q omarchy-mac-overla
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install script rewrites clone btrfs UUID" grep -q 'btrfstune -f -u' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
-check "install script offers persistent root install" grep -q 'Install to a blank USB' \
+check "install script offers persistent root install" grep -q 'Wipe a USB stick and install' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "installed root enables sddm" grep -q 'enable sddm.service' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
@@ -132,9 +132,16 @@ check "install script offers free-space install" grep -q 'Install into free spac
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "free-space install does not wipefs" \
   bash -c 'awk "/^install_into_free_space\\(\\)/,/^action=/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -qv wipefs'
-check "install script offers replace existing OMARCHYROOT" grep -q \
-  'Replace an existing OMARCHYROOT' \
+check "install script offers reinstall existing Omarchy root" grep -q \
+  'Reinstall an existing Omarchy root' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "reinstall picker names the partition first" grep -q 'existing_root_row' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "reinstall picker distinguishes internal NVMe from USB" grep -q \
+  'internal NVMe' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "live GRUB quiets console kmsg" grep -q 'loglevel=3 quiet' \
+  "${repo_root}/configs/usb/grub.cfg"
 check "replace existing root does not mkpart or mklabel" \
   bash -c '! awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -qE "wipefs -a|mklabel gpt|[[:space:]]mkpart root"'
 check "replace existing root asks the desktop user before dd" \
@@ -151,12 +158,22 @@ check "install script labels the installed root OMARCHYROOT" grep -q OMARCHYROOT
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "sh -n omarchy-mac-install" bash -n \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install reports how long it took" grep -q 'finished in' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install offers reboot when finished" grep -q 'Yes, reboot' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install timer starts after the last confirm" grep -q mark_install_start \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "sh -n omarchy-mac-live-welcome" bash -n \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
 check "live welcome only runs on the overlay" grep -q omarchy-mac-overlay-write \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
 check "live welcome offers Install Omarchy" grep -q 'Install Omarchy' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
+check "live welcome prints the Omarchy wordmark" grep -q logo.txt \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
+check "install menu prints the Omarchy wordmark" grep -q logo.txt \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "live welcome execs the installer" grep -q 'exec omarchy-mac-install' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
 check "rootfs installs live welcome on tty1 autologin" grep -q omarchy-mac-live-welcome \
@@ -202,7 +219,7 @@ check "sh -n omarchy-mac-esp.sh" bash -n \
 check "esp-grub loopback tests" "${repo_root}/test/esp-grub"
 check "system GRUB embed searches omarchy-mac-root" grep -q /omarchy-mac-root \
   "${repo_root}/configs/usb/grub-embed-system.cfg"
-check "install offers System ESP GRUB for existing root" grep -q 'Install GRUB for an existing OMARCHYROOT' \
+check "install offers System ESP GRUB for existing root" grep -q 'Write GRUB for an existing Omarchy root' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "own-mode writes BOOTAA64 when the ESP has none" grep -q write_owned_esp_grub \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"

--- a/test/unit
+++ b/test/unit
@@ -98,6 +98,11 @@ check "install script offers persistent root install" grep -q 'Install to a blan
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "installed root enables sddm" grep -q 'enable sddm.service' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "session file is looked up in usr/local/share" grep -q \
+  'usr/local/share/wayland-sessions/omarchy.desktop' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "graphical payload is required before wipefs" \
+  bash -c 'awk "/^install_persistent_root\\(\\)/,/wipefs/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q require_graphical_payload'
 check "installed root uses graphical.target" grep -q 'set-default graphical.target' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "installed root creates a desktop user on @home" grep -q 'subvol=@home' \


### PR DESCRIPTION
The live USB can now install a graphical Omarchy desktop (SDDM autologin, Hyprland, foot, Chromium, Tokyo Night) instead of a tty. The installer asks for the user before the long copy, waits on the cmdline UUID so an internal OMARCHYROOT does not steal the USB boot, and can replace an existing Omarchy root partition without mkpart or touching APFS.

Metal-proven: wipe-install to a USB stick booted to a desktop with network, terminal, and browser; then reinstall onto the existing internal NVMe hole. Live welcome shows the wordmark; when the copy finishes it prints duration and offers a reboot.