### PR TITLE
LUKS on wipe-USB with a single branded unlock

### DIFF
--- a/bin/omarchy-mac-iso-refresh-live
+++ b/bin/omarchy-mac-iso-refresh-live
@@ -1,94 +1,133 @@
 #!/bin/bash
-# Copy the current installer onto the plugged-in live USB (OMARCHYLIVE +
-# OMARCHYISO) without an 8.6G --usb --rootfs rebuild.
+# Update a plugged-in live USB (OMARCHYLIVE + OMARCHYISO) and/or a
+# wipe-installed USB (OMARCHYBOOT). Rebuilds the install initrd. Does not
+# need an 8.6G --usb --rootfs rebuild.
 set -euo pipefail
 (( EUID == 0 )) || { echo "run as root: sudo $0"; exit 1; }
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-live=""
-iso=""
-for d in /dev/sda2 /dev/sdb2 /dev/sdc2; do
-  [[ -b $d ]] || continue
-  label=$(blkid -s LABEL -o value "$d" 2>/dev/null || true)
-  [[ $label == OMARCHYLIVE ]] || continue
-  live=$d
-  break
-done
-for d in /dev/sda1 /dev/sdb1 /dev/sdc1; do
-  [[ -b $d ]] || continue
-  label=$(blkid -s LABEL -o value "$d" 2>/dev/null || true)
-  [[ $label == OMARCHYISO ]] || continue
-  iso=$d
-  break
-done
-[[ -n $live ]] || { echo "error: OMARCHYLIVE not found (plug in the live USB)"; exit 1; }
-[[ -n $iso ]] || { echo "error: OMARCHYISO not found"; exit 1; }
 
-mnt=$(findmnt -n -o TARGET "$live" || true)
-mounted_live=0
-if [[ -z $mnt ]]; then
-  mnt=$(mktemp -d)
-  mount -o subvol=@ "$live" "$mnt"
-  mounted_live=1
-fi
-iso_mnt=$(findmnt -n -o TARGET "$iso" || true)
-mounted_iso=0
-if [[ -z $iso_mnt ]]; then
-  iso_mnt=$(mktemp -d)
-  mount "$iso" "$iso_mnt"
-  mounted_iso=1
-fi
+find_labelled() {
+  local want=$1 d label
+  for d in /dev/sda1 /dev/sda2 /dev/sdb1 /dev/sdb2 /dev/sdc1 /dev/sdc2; do
+    [[ -b $d ]] || continue
+    label=$(blkid -s LABEL -o value "$d" 2>/dev/null || true)
+    [[ $label == "$want" ]] || continue
+    printf '%s\n' "$d"
+    return 0
+  done
+  return 1
+}
+
+live=$(find_labelled OMARCHYLIVE || true)
+iso=$(find_labelled OMARCHYISO || true)
+boot=$(find_labelled OMARCHYBOOT || true)
+[[ -n $live || -n $boot ]] \
+  || { echo "error: plug in the live USB (OMARCHYLIVE) or an installed USB (OMARCHYBOOT)"; exit 1; }
+
+mounted=()
 cleanup() {
-  if (( mounted_iso == 1 )); then
-    umount "$iso_mnt" 2>/dev/null || true
-    rmdir "$iso_mnt" 2>/dev/null || true
-  fi
-  if (( mounted_live == 1 )); then
-    umount "$mnt" 2>/dev/null || true
-    rmdir "$mnt" 2>/dev/null || true
-  fi
+  local dir
+  for dir in "${mounted[@]}"; do
+    umount "$dir" 2>/dev/null || true
+    rmdir "$dir" 2>/dev/null || true
+  done
 }
 trap cleanup EXIT
 
-share=$mnt/usr/local/share/omarchy-mac-iso
-install -d "$mnt/usr/local/sbin" "$share" "$share/initcpio/hooks" "$share/initcpio/install" "$mnt/root"
-install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-install" "$mnt/usr/local/sbin/omarchy-mac-install"
-install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-live-welcome" "$mnt/usr/local/sbin/omarchy-mac-live-welcome"
-install -m644 "$repo_root/configs/usb/rootfs/root-bash-profile" "$mnt/root/.bash_profile"
-install -m644 "$repo_root/configs/usb/rootfs/issue" "$mnt/etc/issue"
-install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" "$share/omarchy-mac-disk.sh"
-install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" "$mnt/usr/local/sbin/omarchy-mac-disk.sh"
-install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-esp.sh" "$share/omarchy-mac-esp.sh"
-install -m644 "$repo_root/configs/usb/grub-embed.cfg" "$share/grub-embed.cfg"
-install -m644 "$repo_root/configs/usb/grub-embed-install.cfg" "$share/grub-embed-install.cfg"
-install -m644 "$repo_root/configs/usb/grub-embed-system.cfg" "$share/grub-embed-system.cfg"
-install -m644 "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" "$share/mkinitcpio-install.conf"
-install -m644 "$repo_root/configs/usb-initcpio/hooks/omarchy-usb-wait" "$share/initcpio/hooks/omarchy-usb-wait"
-install -m644 "$repo_root/configs/usb-initcpio/install/omarchy-usb-wait" "$share/initcpio/install/omarchy-usb-wait"
-install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-asahi-hw.service" \
-  "$mnt/etc/systemd/system/omarchy-mac-asahi-hw.service"
-if [[ -d $iso_mnt/grub ]]; then
-  install -m644 "$repo_root/configs/usb/grub.cfg" "$iso_mnt/grub/grub.cfg"
-fi
-echo "==> copied installer onto the live USB"
+mount_if_needed() {
+  local dev=$1
+  local mnt
+  mnt=$(findmnt -n -o TARGET "$dev" || true)
+  if [[ -z $mnt ]]; then
+    mnt=$(mktemp -d)
+    mount "$dev" "$mnt"
+    mounted+=("$mnt")
+  fi
+  printf '%s\n' "$mnt"
+}
 
-echo "==> pacman --sysroot $mnt -Sy"
-pacman --sysroot "$mnt" -Sy --noconfirm
-echo "==> pacman --sysroot $mnt -S foot xdg-terminal-exec chromium"
-pacman --sysroot "$mnt" -S --noconfirm --needed foot xdg-terminal-exec chromium
-[[ -x $mnt/usr/bin/foot && -x $mnt/usr/bin/chromium && -x $mnt/usr/bin/xdg-terminal-exec ]] \
-  || { echo "error: desktop packages missing after install"; exit 1; }
+if [[ -n $live ]]; then
+  [[ -n $iso ]] || { echo "error: OMARCHYISO not found next to OMARCHYLIVE"; exit 1; }
+  mnt=$(mount_if_needed "$live")
+  if ! findmnt -n -o OPTIONS "$live" | grep -q subvol; then
+    # udisks may have mounted @ already; if we mounted the default, remount @.
+    :
+  fi
+  # Prefer subvol=@ for the payload.
+  if ! findmnt -n "$mnt" | grep -q '\[/@\]'; then
+    umount "$mnt" 2>/dev/null || true
+    mount -o subvol=@ "$live" "$mnt"
+  fi
+  iso_mnt=$(mount_if_needed "$iso")
+  share=$mnt/usr/local/share/omarchy-mac-iso
+  install -d "$mnt/usr/local/sbin" "$share" "$share/initcpio/hooks" "$share/initcpio/install" "$mnt/root"
+  install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-install" "$mnt/usr/local/sbin/omarchy-mac-install"
+  install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-live-welcome" "$mnt/usr/local/sbin/omarchy-mac-live-welcome"
+  install -m644 "$repo_root/configs/usb/rootfs/root-bash-profile" "$mnt/root/.bash_profile"
+  install -m644 "$repo_root/configs/usb/rootfs/issue" "$mnt/etc/issue"
+  install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" "$share/omarchy-mac-disk.sh"
+  install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-disk.sh" "$mnt/usr/local/sbin/omarchy-mac-disk.sh"
+  install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-esp.sh" "$share/omarchy-mac-esp.sh"
+  install -m644 "$repo_root/configs/usb/grub-embed.cfg" "$share/grub-embed.cfg"
+  install -m644 "$repo_root/configs/usb/grub-embed-install.cfg" "$share/grub-embed-install.cfg"
+  install -m644 "$repo_root/configs/usb/grub-embed-system.cfg" "$share/grub-embed-system.cfg"
+  install -m644 "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" "$share/mkinitcpio-install.conf"
+  install -m644 "$repo_root/configs/usb-initcpio/hooks/omarchy-usb-wait" "$share/initcpio/hooks/omarchy-usb-wait"
+  install -m644 "$repo_root/configs/usb-initcpio/install/omarchy-usb-wait" "$share/initcpio/install/omarchy-usb-wait"
+  install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-asahi-hw.service" \
+    "$mnt/etc/systemd/system/omarchy-mac-asahi-hw.service"
+  if [[ -d $iso_mnt/grub ]]; then
+    install -m644 "$repo_root/configs/usb/grub.cfg" "$iso_mnt/grub/grub.cfg"
+  fi
+  echo "==> copied installer onto the live USB"
+  echo "==> pacman --sysroot $mnt -Sy"
+  pacman --sysroot "$mnt" -Sy --noconfirm
+  echo "==> pacman --sysroot $mnt -S foot xdg-terminal-exec chromium cryptsetup"
+  pacman --sysroot "$mnt" -S --noconfirm --needed foot xdg-terminal-exec chromium cryptsetup
+  [[ -x $mnt/usr/bin/cryptsetup ]] || { echo "error: cryptsetup missing after install"; exit 1; }
+fi
 
 out=/tmp/initramfs-omarchy-usb-root.img
 kver=$(uname -r)
+echo "==> mkinitcpio install initrd (plymouth then encrypt)"
 mkinitcpio -n \
   -c "$repo_root/configs/usb-initcpio/mkinitcpio-install.conf" \
   -D /usr/lib/initcpio \
   -D "$repo_root/configs/usb-initcpio" \
   -k "$kver" \
   -g "$out"
-cp -a "$out" "$iso_mnt/initramfs-linux-asahi.img"
+
+if [[ -n $iso ]]; then
+  iso_mnt=$(mount_if_needed "$iso")
+  cp -a "$out" "$iso_mnt/initramfs-linux-asahi.img"
+  echo "==> wrote $iso_mnt/initramfs-linux-asahi.img"
+fi
+
+if [[ -n $boot ]]; then
+  boot_mnt=$(mount_if_needed "$boot")
+  cp -a "$out" "$boot_mnt/initramfs-omarchy-usb-root.img"
+  echo "==> wrote $boot_mnt/initramfs-omarchy-usb-root.img"
+fi
+
+# If a USB LUKS root is already unlocked, stop systemd asking again.
+root_mnt=""
+while read -r name fstype; do
+  [[ $name == sd* && $fstype == crypto_LUKS ]] || continue
+  mapper=$(lsblk -ln -o NAME,TYPE "/dev/$name" | awk '$2=="crypt"{print $1; exit}')
+  [[ -n $mapper ]] || continue
+  root_mnt=$(findmnt -n -o TARGET "/dev/$mapper" || true)
+  [[ -n $root_mnt ]] && break
+done < <(lsblk -ln -o NAME,FSTYPE)
+if [[ -n $root_mnt && -f $root_mnt/etc/crypttab ]]; then
+  if grep -q x-initrd.attach "$root_mnt/etc/crypttab"; then
+    echo "==> crypttab already has x-initrd.attach"
+  else
+    sed -i 's/luks,discard$/luks,discard,x-initrd.attach/' "$root_mnt/etc/crypttab"
+    echo "==> patched $root_mnt/etc/crypttab"
+    cat "$root_mnt/etc/crypttab"
+  fi
+fi
+
 sync
-grep -q 'Reinstall an existing Omarchy root' "$mnt/usr/local/sbin/omarchy-mac-install"
-echo "==> wrote $iso_mnt/initramfs-linux-asahi.img"
-echo "==> Shutdown, boot the live USB."
+echo "==> Shutdown, boot the installed USB. Expect one branded unlock prompt."

--- a/configs/usb-initcpio/hooks/omarchy-usb-wait
+++ b/configs/usb-initcpio/hooks/omarchy-usb-wait
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 #
 # Root is on USB. dwc3-apple can take several seconds. Wait for the
-# cmdline UUID before the filesystems hook mounts it. Do not treat
-# LABEL=OMARCHYROOT as success when a UUID is set: NVMe hole installs
-# use that label too, so the wait would return before USB enumerates.
+# device the next hook needs: cryptdevice UUID (LUKS) before encrypt,
+# otherwise root UUID before filesystems. Do not treat LABEL=OMARCHYROOT
+# as success when a UUID is set: NVMe hole installs use that label too.
 
 hang() {
   echo "==> $*" >/dev/console
@@ -14,12 +14,13 @@ hang() {
   done
 }
 
-root_uuid_from_cmdline() {
-  local arg
+uuid_from_cmdline() {
+  local prefix=$1 arg rest
   for arg in $(cat /proc/cmdline); do
     case "$arg" in
-      root=UUID=*)
-        echo "${arg#root=UUID=}"
+      ${prefix}=UUID=*)
+        rest=${arg#${prefix}=UUID=}
+        echo "${rest%%:*}"
         return 0
         ;;
     esac
@@ -35,14 +36,19 @@ run_hook() {
   fi
   sleep 2
 
-  uuid=$(root_uuid_from_cmdline || true)
+  crypt_uuid=$(uuid_from_cmdline cryptdevice || true)
+  uuid=$(uuid_from_cmdline root || true)
   i=0
   while [ "$i" -lt 45 ]; do
-    if [ -n "$uuid" ] && [ -e /dev/disk/by-uuid/"$uuid" ]; then
+    if [ -n "$crypt_uuid" ] && [ -e /dev/disk/by-uuid/"$crypt_uuid" ]; then
+      echo "==> omarchy-usb-wait: cryptdevice UUID=$crypt_uuid" >/dev/console
+      return 0
+    fi
+    if [ -z "$crypt_uuid" ] && [ -n "$uuid" ] && [ -e /dev/disk/by-uuid/"$uuid" ]; then
       echo "==> omarchy-usb-wait: root UUID=$uuid" >/dev/console
       return 0
     fi
-    if [ -z "$uuid" ] && [ -e /dev/disk/by-label/OMARCHYROOT ]; then
+    if [ -z "$crypt_uuid" ] && [ -z "$uuid" ] && [ -e /dev/disk/by-label/OMARCHYROOT ]; then
       echo "==> omarchy-usb-wait: root label=OMARCHYROOT" >/dev/console
       return 0
     fi

--- a/configs/usb-initcpio/mkinitcpio-install.conf
+++ b/configs/usb-initcpio/mkinitcpio-install.conf
@@ -22,7 +22,7 @@ BINARIES=()
 
 FILES=()
 
-HOOKS=(base asahi udev omarchy-usb-wait filesystems)
+HOOKS=(base asahi udev kms keyboard plymouth omarchy-usb-wait encrypt filesystems)
 
 COMPRESSION="zstd"
 COMPRESSION_OPTIONS=(-T0 -3)

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Clone this live USB, wipe-install a USB, or install into GPT free space
-# (never mklabel a disk that already has Apple partitions). Not an Omarchy
-# desktop install. No LUKS on this cut.
+# (never mklabel a disk that already has Apple partitions). LUKS is offered
+# on wipe-USB only; free-space and replace-existing stay unencrypted.
 set -euo pipefail
 
 fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
@@ -389,9 +389,10 @@ EOF
 }
 
 install_persistent_root() {
-  local payload_bytes min_bytes source_esp esp_part root_part
+  local payload_bytes min_bytes source_esp esp_part root_part root_dev
   local root_mnt esp_mnt live_esp_mnt
-  local root_uuid esp_uuid grub_cfg work
+  local root_uuid esp_uuid luks_uuid grub_cfg work
+  local encrypt_root=0 linux_line
 
   command -v parted >/dev/null || fail "parted not found"
   command -v mkfs.vfat >/dev/null || fail "mkfs.vfat not found — rebuild with --usb --rootfs (dosfstools)"
@@ -406,9 +407,15 @@ install_persistent_root() {
   pick_target_disk "$min_bytes"
   printf '==> confirm DESTROY of %s (arrow keys, then enter)\n' "$target_dev"
   gum confirm \
-    "DESTROY $target_dev (${choice#*  }) and install a persistent USB root (no overlay, no LUKS)?" \
+    "DESTROY $target_dev (${choice#*  }) and install a persistent USB root (no overlay)?" \
     || fail "cancelled"
   printf '==> confirmed\n'
+  if gum confirm --default --affirmative "Encrypt" --negative "No encryption" \
+    "Encrypt the disk? Recommended. Same password as the desktop user."; then
+    encrypt_root=1
+    command -v cryptsetup >/dev/null \
+      || fail "cryptsetup not found — rebuild with --usb --rootfs"
+  fi
 
   mark_install_start
   source_esp=$(esp_partition_on "$live_disk" || true)
@@ -436,31 +443,44 @@ install_persistent_root() {
   printf '==> formatting ESP %s\n' "$esp_part"
   mkfs.vfat -F 32 -n OMARCHYBOOT "$esp_part"
 
-  printf '==> copying payload %s -> %s\n' "$live_partition" "$root_part"
-  dd if="$live_partition" of="$root_part" bs=4M status=progress conv=fsync oflag=sync
+  root_dev=$root_part
+  if (( encrypt_root == 1 )); then
+    printf '==> luksFormat %s\n' "$root_part"
+    printf '%s' "$desktop_pass" | cryptsetup luksFormat --type luks2 --batch-mode --key-file=- "$root_part"
+    printf '%s' "$desktop_pass" | cryptsetup open --key-file=- "$root_part" root
+    root_dev=/dev/mapper/root
+    luks_uuid=$(blkid -s UUID -o value "$root_part")
+    [[ -n $luks_uuid ]] || fail "no UUID on LUKS container $root_part"
+  fi
+
+  printf '==> copying payload %s -> %s\n' "$live_partition" "$root_dev"
+  dd if="$live_partition" of="$root_dev" bs=4M status=progress conv=fsync oflag=sync
   sync
   partprobe "$target_dev" 2>/dev/null || true
   command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
 
   root_mnt=$(mktemp -d)
-  mount -o subvol=@ "$root_part" "$root_mnt"
-  printf '==> btrfs resize max on %s\n' "$root_part"
+  mount -o subvol=@ "$root_dev" "$root_mnt"
+  printf '==> btrfs resize max on %s\n' "$root_dev"
   btrfs filesystem resize max "$root_mnt"
   btrfs filesystem label "$root_mnt" OMARCHYROOT
   umount "$root_mnt"
 
   if command -v btrfs >/dev/null; then
-    btrfs device scan --forget "$root_part" || true
+    btrfs device scan --forget "$root_dev" || true
   fi
-  btrfstune -f -u "$root_part"
-  mount -o subvol=@ "$root_part" "$root_mnt"
+  btrfstune -f -u "$root_dev"
+  mount -o subvol=@ "$root_dev" "$root_mnt"
 
-  root_uuid=$(blkid -s UUID -o value "$root_part")
-  [[ -n $root_uuid ]] || fail "no UUID on $root_part after btrfstune"
+  root_uuid=$(blkid -s UUID -o value "$root_dev")
+  [[ -n $root_uuid ]] || fail "no UUID on $root_dev after btrfstune"
 
   printf 'UUID=%s / btrfs subvol=@,compress=zstd:1 0 0\n' "$root_uuid" >"$root_mnt/etc/fstab"
   printf 'UUID=%s /home btrfs subvol=@home,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
   printf 'UUID=%s /var/log btrfs subvol=@log,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
+  if (( encrypt_root == 1 )); then
+    printf 'root UUID=%s none luks,discard,x-initrd.attach\n' "$luks_uuid" >"$root_mnt/etc/crypttab"
+  fi
   printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
   cat >"$root_mnt/etc/issue" <<'EOF'
 Omarchy Mac (installed). SDDM autologin.
@@ -496,6 +516,11 @@ EOF
     rmdir "$live_esp_mnt"
   fi
 
+  linux_line="root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3 quiet splash"
+  if (( encrypt_root == 1 )); then
+    linux_line="root=UUID=$root_uuid rw rootflags=subvol=@ cryptdevice=UUID=$luks_uuid:root:allow-discards loglevel=3 quiet splash"
+  fi
+
   grub_cfg=$work/grub.cfg
   cat >"$grub_cfg" <<EOF
 echo '========================================'
@@ -507,7 +532,7 @@ set default=0
 search --no-floppy --file /omarchy-usb-install --set=root
 
 menuentry 'Omarchy Mac (USB root)' {
-  linux /vmlinuz-linux-asahi root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3 quiet splash
+  linux /vmlinuz-linux-asahi $linux_line
   initrd /initramfs-omarchy-usb-root.img
 }
 EOF
@@ -525,12 +550,15 @@ EOF
   esp_uuid=$(blkid -s UUID -o value "$esp_part")
   printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"
 
-  personalize_graphical_session "$root_mnt" "$root_part"
+  personalize_graphical_session "$root_mnt" "$root_dev"
 
   sync
   umount "$esp_mnt"
   umount "$root_mnt"
   rm -rf "$esp_mnt" "$root_mnt" "$work"
+  if (( encrypt_root == 1 )); then
+    cryptsetup close root
+  fi
 
   printf '==> done. Unplug the live USB %s, cold-start, boot the installed disk %s.\n' \
     "$source_dev" "$target_dev"

--- a/configs/usb/rootfs/packages
+++ b/configs/usb/rootfs/packages
@@ -13,6 +13,7 @@ foot
 xdg-terminal-exec
 # SUPER+Shift+Return → omarchy-launch-browser (chromium.desktop).
 chromium
+cryptsetup
 snapper
 plymouth
 gnome-keyring

--- a/test/unit
+++ b/test/unit
@@ -34,6 +34,9 @@ check "MINIROOTFS_SHA256 is 64 hex chars" bash -c "[[ '${MINIROOTFS_SHA256}' =~ 
 check "KERNEL_PKG_SHA256 is 64 hex chars" bash -c "[[ '${KERNEL_PKG_SHA256}' =~ ^[0-9a-f]{64}\$ ]]"
 
 check "omarchy-mac-iso-make --help works offline" "${repo_root}/bin/omarchy-mac-iso-make" --help
+check "refresh-live can update OMARCHYBOOT without the live USB" grep -q \
+  'OMARCHYBOOT' \
+  "${repo_root}/bin/omarchy-mac-iso-refresh-live"
 check "omarchy-mac-iso-make --help mentions --usb" \
   grep -q -- '--usb' <("${repo_root}/bin/omarchy-mac-iso-make" --help)
 check "omarchy-mac-iso-make --help mentions --rootfs" \
@@ -189,8 +192,27 @@ check "install GRUB searches omarchy-usb-install" grep -q /omarchy-usb-install \
 check "install initramfs waits for USB root" grep -q OMARCHYROOT \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-wait"
 check "usb-wait does not succeed on OMARCHYROOT when UUID is set" grep -q \
-  'if \[ -z "$uuid" \] && \[ -e /dev/disk/by-label/OMARCHYROOT \]' \
+  'if \[ -z "$crypt_uuid" \] && \[ -z "$uuid" \] && \[ -e /dev/disk/by-label/OMARCHYROOT \]' \
   "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-wait"
+check "usb-wait prefers cryptdevice UUID over root UUID" grep -q \
+  'omarchy-usb-wait: cryptdevice UUID=' \
+  "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-wait"
+check "install initramfs runs encrypt after the USB wait" grep -q \
+  'omarchy-usb-wait encrypt filesystems' \
+  "${repo_root}/configs/usb-initcpio/mkinitcpio-install.conf"
+check "install initramfs starts plymouth before encrypt" grep -q \
+  'plymouth omarchy-usb-wait encrypt' \
+  "${repo_root}/configs/usb-initcpio/mkinitcpio-install.conf"
+check "wipe-USB install can luksFormat" grep -q 'cryptsetup luksFormat' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "wipe-USB GRUB can pass cryptdevice" grep -q 'cryptdevice=UUID=' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "free-space install does not luksFormat" \
+  bash -c '! awk "/^install_into_free_space\\(\\)/,/^install_over_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q luksFormat'
+check "replace existing root does not luksFormat" \
+  bash -c '! awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q luksFormat'
+check "rootfs extra packages include cryptsetup" grep -qx cryptsetup \
+  "${repo_root}/configs/usb/rootfs/packages"
 check "install initramfs lists dwc3_apple" grep -q dwc3_apple \
   "${repo_root}/configs/usb-initcpio/mkinitcpio-install.conf"
 check "sh -n omarchy-usb-wait" sh -n \


### PR DESCRIPTION
Wipe-USB can encrypt the root with the desktop user password. The install initrd waits for that LUKS UUID on Type-C, shows the Omarchy Plymouth prompt once, then opens the volume. systemd is told the mapping already exists (`x-initrd.attach`), so it does not ask a second time.

Free-space and replace-existing stay unencrypted. Metal-proven on a USB stick: luksFormat, passphrase at the branded lock, desktop session. Refresh-live can drop the new initrd onto OMARCHYBOOT without another payload copy.