### PR TITLE
Copy the live tree for install, with LUKS on every path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# Agents
+
+This repo is **omarchy-mac-iso**: the Apple Silicon live USB and installer. It is not [omarchy-mac](https://github.com/omarchy-mac/omarchy-mac) (the installed desktop). Edits here do nothing on a running machine until they are copied onto a USB (or into an installed ESP).
+
+`plans/apple-silicon-image.md` is the destination design. `README.md` is how to build and flash.
+
+## What an agent is allowed to touch
+
+- Live USB image, initramfs, installer TUI, GRUB embeds, and tests in this tree
+- A plugged-in live USB via `sudo ./bin/omarchy-mac-iso-refresh-live` when the user asked to try a change on metal
+
+Never:
+
+- `mklabel`, `wipefs`, or partition-delete on a disk that already has Apple GPT types (APFS / iBoot / Recovery). Shrinking APFS happens in **macOS only**. Altering APFS from Linux can force a DFU restore
+- Put hostnames, USB brand names, or other machine-specific strings into shipped installer copy
+- Open a PR unless the user asked for one
+- Treat a successful `./test/unit` as a visual or metal proof
+
+## Two artifacts, two initrds
+
+The USB GPT is ESP (`OMARCHYISO`) + btrfs payload (`OMARCHYLIVE`, subvol `@`).
+
+| Boot | ESP file | Initrd config |
+|------|----------|----------------|
+| Live installer | `initramfs-omarchy-usb.img` | `configs/usb-initcpio/mkinitcpio.conf` (overlay, `omarchy-usb-live`) |
+| Installed disk | `initramfs-linux-asahi.img` (copied as `initramfs-omarchy-usb-root.img` or `EFI/omarchy/initramfs.img`) | `configs/usb-initcpio/mkinitcpio-install.conf` (wait + encrypt + Plymouth) |
+
+`refresh-live` must rebuild **both** when the live USB is plugged in. Updating only the install initrd leaves live boot on a stale `initramfs-omarchy-usb.img`.
+
+A full image is `sudo ./bin/omarchy-mac-iso-make --usb --rootfs`. Use refresh for installer scripts, GRUB cfg, initrds, and a short package list on an existing stick.
+
+## Installer paths
+
+`omarchy-mac-install` on the live overlay:
+
+- **Wipe USB** / **free space** / **replace existing** — `mkfs.btrfs` then `tar` of used files from the overlay lowerdir (`/run/omarchy-root`). Not a `dd` of the 8GiB payload
+- **Clone** — still `dd` through the last partition; rewrite the clone btrfs UUID
+- LUKS is offered on wipe, free-space, and replace. Same password as the desktop user. New LUKS volumes get label `OMARCHYROOT`
+- Replace-existing looks for btrfs `OMARCHYROOT` **or** `crypto_LUKS` with that label / GPT name `root`. Asahi's own LUKS has neither — do not offer it
+- Identity validation re-prompts. Before the copy, show a table of action, target, user, password stars, hostname, encryption, then "Does this look right?"
+- System ESP: **piggyback** (`custom.cfg` only) if `BOOTAA64.EFI` already exists; **own** if the ESP has none. Never rewrite `m1n1/`, `vendorfw/`, or `asahi/`
+
+Free space needs an unallocated GPT hole (from a macOS APFS shrink or Asahi UEFI-only). If the hole is already a partition, use replace-existing.
+
+## Tests
+
+```
+./test/unit
+```
+
+That runs `bash -n`, installer greps, `test/partition`, and `test/esp-grub`. It does not boot a Mac.
+
+Grep tests must fail if the behavior is removed. Do not match a string that still exists in a comment after the real call is gone.
+
+## Metal
+
+- Firmware for Wi-Fi comes from the **internal** ESP (`asahi` hook). The stick does not ship it
+- U-Boot: cold power on (warm reboot often misses Type-C). `usb reset` until storage appears. Do not `saveenv`. A machine that already has Linux on NVMe must interrupt U-Boot or NVMe GRUB wins
+- A Mac with no Asahi/m1n1 cannot boot this USB. iBoot will not load it until macOS has run the Asahi **UEFI-only** provision (`kmutil`). That step is out of this repo
+- Live boot should stay quiet (`loglevel=0`, `systemd.show_status=0`, live GRUB masks Plymouth/ldconfig). Installed disks keep `quiet splash` and Plymouth. Confirm on the live stick after refresh, not only in git
+
+## Style
+
+- `#!/bin/bash` in this repo's scripts
+- Full English names
+- `[[ ]]` for strings/files, `(( ))` for numbers
+- Installer `fail` exits; user validation uses `retry` and loops
+
+## Working from another machine
+
+Unit tests and editing this git tree work on any host (including x86 Omarchy). `refresh-live` and live/install `mkinitcpio` need a machine that already runs `linux-asahi` (dwc3-apple, host modules, vendor firmware layout). After a wipe of the Asahi box, keep a clone of this repo on a second computer so the branch still exists even if the NVMe does not.

--- a/README.md
+++ b/README.md
@@ -1,104 +1,29 @@
 # Omarchy Mac ISO
 
-Install images for Omarchy on Apple Silicon. The shipped artifact is a
-GPT disk image (`.img`) with a FAT32 ESP, not an ISO9660 file — the
-repo name matches Omarchy's x86 ISO so people can find it.
+Install images for Omarchy on Apple Silicon. The shipped artifact is a GPT disk image (`.img`) with a FAT32 ESP, not an ISO9660 file — the repo name matches Omarchy's x86 ISO so people can find it.
 
-Destination design: [plans/apple-silicon-image.md](plans/apple-silicon-image.md).
-That is m1n1 → U-Boot → GRUB `BOOTAA64.EFI` → `linux-asahi` → a `root.img`
-payload, proven on an M2 Max. This repo owns the live boot environment and
-installer; [omarchy-mac](https://github.com/omarchy-mac/omarchy-mac) owns
-the installed system.
+This repo owns the live USB and installer. [omarchy-mac](https://github.com/omarchy-mac/omarchy-mac) owns the installed desktop. Destination design: [plans/apple-silicon-image.md](plans/apple-silicon-image.md). How to work in this tree: [AGENTS.md](AGENTS.md).
 
-Default branch is `main`. That is unrelated to `omarchy-mac`'s `main`
-(still v3.x); this tree has no v3 history.
+Default branch is `main`. That is unrelated to `omarchy-mac`'s `main` (still v3.x); this tree has no v3 history.
 
-## M0 — QEMU boot harness
-
-M0 proves a reproducible ARM64 build crosses a generic AArch64 UEFI
-boundary under QEMU, reaches Linux userspace, and emits a readiness
-signal. **It will not boot an Apple Silicon Mac.** There is no m1n1,
-U-Boot, Asahi kernel, or USB ESP in this artifact.
-
-```
-source
-  -> ./bin/omarchy-mac-iso-make
-  -> release/omarchy-mac-iso-arm64/{vmlinuz,initramfs.img}
-  -> ./bin/omarchy-mac-iso-boot
-  -> AArch64 UEFI (edk2) on QEMU virt
-  -> Linux kernel + initramfs
-  -> live userspace
-  -> "OMARCHY_MAC_ISO_READY" on the serial console
-```
-
-Alpine aarch64 and `linux-virt` are throwaway M0 content so the harness
-can run on a laptop without Asahi hardware or Docker. They are not the
-installer distribution. Do not grow the TUI, disk partitioning, or LUKS
-on top of this userspace — the next milestone replaces the payload with
-the GPT `.img` in the plan.
-
-## Requirements (M0)
-
-- macOS or Linux, x86_64 or aarch64
-- [`qemu`](https://www.qemu.org/) on `PATH`
-  - macOS: `brew install qemu` (includes AArch64 UEFI firmware)
-  - Debian/Ubuntu: `apt install qemu-system-arm qemu-efi-aarch64`
-  - Arch: `pacman -S qemu-system-aarch64 edk2-armvirt`
-- `curl`, `tar`, `cpio`, `gzip`, `shasum`
-- No root privileges and no virtual disks: M0 boots from RAM
-
-Hardware acceleration is used when available (HVF on Apple Silicon, KVM
-on Linux aarch64 with `/dev/kvm`) and falls back to TCG otherwise.
-
-## Build / boot / test (M0)
-
-```
-./bin/omarchy-mac-iso-make
-./bin/omarchy-mac-iso-boot          # Ctrl-A X to quit
-./test/unit                        # fast, no network, no VM
-./test/smoke                       # full build + boot + marker + teardown
-```
-
-`omarchy-mac-iso-make` downloads pinned, checksummed upstream artifacts
-(cached under `~/.cache/omarchy-mac-iso/`) and writes
-`release/omarchy-mac-iso-arm64/{vmlinuz,initramfs.img,BUILD_INFO}`.
-
-On smoke failure, the serial log is printed and the run directory is
-kept for debugging.
+A Mac with no Asahi/m1n1 cannot boot this USB. iBoot will not load it until macOS has run the Asahi **UEFI-only** provision. Shrink APFS from macOS, never from Linux.
 
 ## USB image (Apple Silicon host)
 
 On a machine that already runs `linux-asahi`:
 
 ```
-./bin/omarchy-mac-iso-make --usb
-```
-
-Writes `release/omarchy-mac-iso-usb/omarchy-mac-usb.img` — GPT with a FAT32
-ESP labelled `OMARCHYISO` (standalone GRUB, this host's `linux-asahi`,
-initramfs with `dwc3-apple`) and a btrfs payload labelled `OMARCHYLIVE`
-(subvol `@`, tiny busybox `/sbin/init`). No root required. Copying files
-onto an existing FAT stick is not enough — the payload is its own partition.
-
-Systemd userspace plus the Omarchy *shell* packages — needs root,
-`arch-install-scripts`, and local `omarchy-*.pkg.tar.*` (default
-`~/.local/share/omarchy/build-output`):
-
-```
 sudo ./bin/omarchy-mac-iso-make --usb --rootfs
 ```
 
-Autologin root on tty1 (`multi-user.target`, not SDDM). Payload is 8GiB
-btrfs: NetworkManager, Asahi mesa / asahi-audio, gum, Hyprland, Quickshell,
-SDDM, `omarchy` from those tarballs. Still does **not** pacstrap
-`linux-asahi` or `asahi-scripts` (host ESP). Vendor firmware is copied from
-the internal ESP at boot. Default `--usb` without `--rootfs` still hangs at
-busybox pid 1. Override size with `OMARCHY_USB_PAYLOAD_BYTES`; package
-search with `OMARCHY_LOCAL_PACKAGES`. Proven on metal 2026-08-25 (Lexar,
-8GiB `OMARCHYLIVE`, `bootflow` `usb_mass_storage`): autologin
-`root@omarchy-mac-live`, `pacman -Q` reported `omarchy 4.0.0-1`,
-`hyprland 0.56.1-3`, `quickshell 0.3.1-1`, `sddm 0.21.0-7`. Still a tty,
-not a graphical session.
+Writes `release/omarchy-mac-iso-usb/omarchy-mac-usb.img` — GPT with:
+
+- ESP labelled `OMARCHYISO` — standalone GRUB, this host's `linux-asahi`, live initrd (`initramfs-omarchy-usb.img`, `dwc3-apple`) and install initrd (`initramfs-linux-asahi.img`)
+- btrfs labelled `OMARCHYLIVE`, subvol `@` — systemd userspace plus Omarchy shell packages (Hyprland, Quickshell, SDDM, gum, NetworkManager, cryptsetup). Live session is tty autologin (`multi-user.target`), not a graphical login
+
+Needs root, `arch-install-scripts`, and local `omarchy-*.pkg.tar.*` (default `~/.local/share/omarchy/build-output`). Does **not** pacstrap `linux-asahi` or `asahi-scripts` (those touch the host ESP). Vendor firmware is copied from the **internal** ESP at boot.
+
+`--usb` without `--rootfs` still writes a tiny busybox payload and is not the installer. Override payload size with `OMARCHY_USB_PAYLOAD_BYTES`; package search with `OMARCHY_LOCAL_PACKAGES`.
 
 Flash (destroys the target stick):
 
@@ -106,14 +31,21 @@ Flash (destroys the target stick):
 sudo dd if=release/omarchy-mac-iso-usb/omarchy-mac-usb.img of=/dev/sdX bs=4M status=progress conv=fsync
 ```
 
+Copying files onto an existing FAT stick is not enough — the payload is its own partition.
+
+### Refresh an existing live USB
+
+Does not need an 8GiB rebuild. Updates installer scripts, GRUB cfg, systemd quieting, and rebuilds **both** initrds (live and install):
+
+```
+sudo ./bin/omarchy-mac-iso-refresh-live
+```
+
+Plug in the live stick (`OMARCHYISO` + `OMARCHYLIVE`). It can also update a wipe-installed USB (`OMARCHYBOOT`) and `/boot/EFI/omarchy/initramfs.img` on a machine that already has Omarchy. You want `copied installer onto the live USB` and `wrote …/initramfs-omarchy-usb.img`.
+
 ### U-Boot
 
-**Shutdown, then power on** — a warm reboot often leaves Type-C/PD
-unenumerated (`0 Storage Device(s) found`). Interrupt U-Boot (~1s) if NVMe
-already has Linux. If `usb storage` is empty or U-Boot skips the stick
-(`Cannot read configuration, skipping device 05dc:c753` on the Lexar),
-`usb reset` until storage appears (twice on metal, 2026-08-23). Do not
-`saveenv`.
+**Shutdown, then power on** — a warm reboot often leaves Type-C unenumerated. Interrupt U-Boot (~1s) if NVMe already has Linux; a UEFI-only Mac with no NVMe EFI should take the stick. If `usb storage` is empty, `usb reset` until it appears. Do not `saveenv`.
 
 ```
 usb reset
@@ -122,77 +54,58 @@ load usb 0:1 ${kernel_addr_r} /EFI/BOOT/BOOTAA64.EFI
 bootefi ${kernel_addr_r} ${fdtcontroladdr}
 ```
 
-`bootflow select` of a USB *row* can still load NVMe's
-`/EFI/BOOT/BOOTAA64.EFI` (same path). `bootflow scan -l` then select the
-`usb_mass_storage` entry (seq 2 on metal, 2026-08-24) and `bootflow boot`
-does load the stick. `load usb 0:1 …` / `bootefi` still works. `bootcmd_usb0`
-is not defined. Live GRUB prints `OMARCHY USB GRUB`; installed GRUB prints
-`OMARCHY USB INSTALL` / menu `Omarchy Mac (USB root)`. Omarchy Linux /
-Advanced options means you are on NVMe.
+`bootflow scan -l` then the `usb_mass_storage` entry also works. `bootflow select` of a USB *row* can still load NVMe's `BOOTAA64.EFI` (same path). Live GRUB prints `OMARCHY USB GRUB`. "Omarchy Linux / Advanced options" means you are on NVMe.
 
-Hiding NVMe `EFI/BOOT/BOOTAA64.EFI` (rename to `.omarchy-bak`; m1n1 stays)
-makes U-Boot take USB GRUB — proven 2026-08-24 after `usb reset` (Type-C
-still needs that). Restore from macOS if Linux will not boot: Apple picker
-(hold power) → macOS. `diskutil mount "EFI - OMARC"` can fail even when
-the volume is fine; then:
+Live boot is meant to be quiet (`loglevel=0`, systemd status off, Plymouth and ldconfig masked on the installer USB only). Installed disks keep `quiet splash` and branded Plymouth.
+
+### Installer
+
+On the live USB, tty1 autologin runs `omarchy-mac-install`. It never `mklabel`s a disk that already has Apple partition types.
+
+It asks for a username, password (re-prompts on mismatch), hostname (empty → `omarchy`), and whether to encrypt (default yes, same password as the user). Then it shows a table of every choice and **Does this look right?** before copying. Tokyo Night is seeded so the first graphical frame is not unthemed.
+
+| Action | What it does |
+|--------|----------------|
+| **Install into free space** | `parted mkpart` in an existing GPT hole only. APFS/iBoot/Recovery stay. Needs unallocated space (macOS APFS shrink or Asahi UEFI-only leftover) |
+| **Reinstall an existing Omarchy root** | Formats that partition only — no `mkpart`, no `mklabel`. Finds btrfs `OMARCHYROOT` or a LUKS volume labelled `OMARCHYROOT` / GPT name `root`. Does not offer Asahi's own LUKS |
+| **Wipe a USB stick and install** | GPT ESP (`OMARCHYBOOT`) + root filling the stick. Persistent desktop, no overlay |
+| **Write GRUB for an existing Omarchy root** | Bootloader only. Skips encrypted roots (needs the inner UUID) |
+| **Clone** | `dd` through the last partition onto another stick; rewrites the clone btrfs UUID |
+
+Wipe, free-space, and replace **copy used files** (`tar` of the overlay lowerdir onto a fresh btrfs `@` / `@home` / `@log`). They do not `dd` the 8GiB payload. Clone is still a block copy. Metal: ~3.5G used tree onto an encrypted NVMe hole in **1m 45s**, SDDM autologin, Hyprland.
+
+LUKS is offered on wipe, free-space, and replace. New containers get label `OMARCHYROOT`. Install initrd runs Plymouth before `encrypt` so there is one branded unlock, not a text prompt then Plymouth.
+
+### System ESP after a disk install
+
+Two modes, never `mkfs` of the ESP, never `update-m1n1`:
+
+- **Piggyback** — `BOOTAA64.EFI` already exists: write `grub/custom.cfg` only, leave the file bytes unchanged
+- **Own** — UEFI-only ESP with no GRUB: write `BOOTAA64.EFI` and marker `/omarchy-mac-root`
+
+Kernels live under `EFI/omarchy/` so a later `grub-mkconfig` on that ESP does not pick them up as stray entries. Backups of `BOOTAA64.EFI` / `grub.cfg` / `custom.cfg` are `*.omarchy-bak` on the ESP. `m1n1/` / `vendorfw/` / `asahi/` hashes must match after.
+
+### Wi-Fi on the live USB
+
+nmtui **Rescan** until SSIDs appear, then Activate. A few rescans is normal.
+
+## Tests
 
 ```
-sudo mkdir -p /Volumes/esp
-sudo mount -t msdos /dev/disk0s4 /Volumes/esp
-mv /Volumes/esp/EFI/BOOT/BOOTAA64.EFI.omarchy-bak \
-   /Volumes/esp/EFI/BOOT/BOOTAA64.EFI
-sudo umount /Volumes/esp
+./test/unit
 ```
 
-Copy the pancake `BOOTAA64.EFI`, not the Lexar's `EFI/BOOT/` file (that is
-USB GRUB). A spare copy lives on the live ESP as `omarchy-restore/`.
+Syntax, installer greps, partition loopback, ESP GRUB loopback. No network, no Mac. `./test/smoke` is the M0 QEMU harness.
 
-Wi-Fi: nmtui Rescan until SSIDs appear (a few rescans is normal), then
-Activate. On the persistent USB root (2026-08-24) that was enough for
-`ping www.google.com`; nmcli is optional.
+## M0 — QEMU boot harness
 
-### Clone vs install
+M0 proves a reproducible ARM64 build crosses a generic AArch64 UEFI boundary under QEMU. **It will not boot an Apple Silicon Mac.** There is no m1n1, U-Boot, Asahi kernel, or USB ESP in that artifact.
 
-On the live USB, `omarchy-mac-install` (refuses NVMe and Apple partition
-GUIDs):
+```
+./bin/omarchy-mac-iso-make
+./bin/omarchy-mac-iso-boot          # Ctrl-A X to quit
+```
 
-- **Clone** — `dd` through the last partition onto another stick (a 16GB-class
-  stick is often smaller than the live USB). Unmounts source and target first
-  unless this *is* the running live overlay. Rewrites the clone btrfs UUID.
-  Proven from Omarchy and from the live USB (2026-08-23): Lexar ↔ 14.5G stick,
-  `gum 2.0.0`, `fnmode=1`.
-- **Install (wipe USB)** — GPT ESP (`OMARCHYBOOT`) + btrfs root filling the
-  disk. Prompts for a desktop user, enables SDDM autologin
-  (`omarchy.desktop` in `/usr/local/share/wayland-sessions`, Hyprland
-  uwsm) and `graphical.target`. Live USB
-  stays tty autologin. Proven on an M2 Max (2026-08-24): 14.5G stick,
-  then console-only; graphical session not metal-proven yet. GRUB must
-  search `/omarchy-usb-install`, not `/initramfs-linux-asahi.img`
-  (that file is the NVMe LUKS initramfs).
-- **Install into free space** — `parted mkpart` in an existing GPT hole only.
-  Never `mklabel`/`wipefs`. Proven on the Lexar hole (keep live
-  `OMARCHYISO`/`OMARCHYLIVE`, new `OMARCHYROOT` 11.4G) and on this NVMe
-  after shrinking APFS **from macOS** (2026-08-24): p7 46G,
-  `root@omarchy-mac`, existing Omarchy still the default GRUB entry.
-  Parted whole-MiB starts can sit inside APFS on 4K NVMe — mkpart insets
-  1MiB. Apple GPT snapshots use `lsblk -l` so tree glyphs do not abort
-  after the new partition appears. Two System ESP modes: **piggyback** if
-  `BOOTAA64.EFI` already exists (`custom.cfg` only, file unchanged);
-  **own** if the ESP is UEFI-only (no GRUB) — same `grub-mkstandalone`
-  recipe as wipe-USB, marker `/omarchy-mac-root`, never `mkfs` or
-  `update-m1n1`. Kernel/initrd go in `EFI/omarchy/` so **any**
-  `grub-mkconfig` on that ESP (pacman hook on the installed OS, not
-  only the live USB) misses them. Legacy `vmlinuz-omarchy-usb-root` and
-  `initramfs-omarchy-usb-root.img` on the ESP root are removed. `m1n1/` /
-  `vendorfw/` / `asahi/` hashes must match after. Installer backups of
-  `BOOTAA64.EFI` / `grub.cfg` / `custom.cfg` are `*.omarchy-bak` on the
-  ESP (timestamped if a bak already exists). Kernel copies under
-  `EFI/omarchy/` are not backed up — they are 50MiB and reproducible
-  from the live USB. Other suffixes on this machine (`.iso-bak`,
-  `.hand-*`, `.gen-badroot`) are ad-hoc restore copies, not installer. A fourth
-  menu item writes GRUB for an existing `OMARCHYROOT` without `mkpart`.
-  **Own-mode metal 2026-08-25:** hid NVMe GRUB, rebuilt live USB, free-space
-  `mkpart` p7, wrote `BOOTAA64.EFI`, USB unplugged → `root@omarchy-mac`.
-  U-Boot only loads one `BOOTAA64.EFI`; own-mode replaces an existing
-  Omarchy GRUB. Restore pancake with the original file (not the live USB's)
-  then `grub-mkconfig` so `quiet splash` brings the branded Plymouth unlock.
+Alpine aarch64 and `linux-virt` are throwaway so the harness can run without Asahi hardware. Do not grow the installer TUI on top of that userspace.
+
+Requirements: `qemu` on PATH (HVF or KVM when available, else TCG), `curl`, `tar`, `cpio`, `gzip`, `shasum`. No root. Artifacts cache under `~/.cache/omarchy-mac-iso/`.

--- a/bin/omarchy-mac-iso-refresh-live
+++ b/bin/omarchy-mac-iso-refresh-live
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Update a plugged-in live USB (OMARCHYLIVE + OMARCHYISO) and/or a
-# wipe-installed USB (OMARCHYBOOT). Rebuilds the install initrd. Does not
-# need an 8.6G --usb --rootfs rebuild.
+# wipe-installed USB (OMARCHYBOOT). Rebuilds the live initrd and the
+# install initrd. Does not need an 8.6G --usb --rootfs rebuild.
 set -euo pipefail
 (( EUID == 0 )) || { echo "run as root: sudo $0"; exit 1; }
 
@@ -22,8 +22,10 @@ find_labelled() {
 live=$(find_labelled OMARCHYLIVE || true)
 iso=$(find_labelled OMARCHYISO || true)
 boot=$(find_labelled OMARCHYBOOT || true)
-[[ -n $live || -n $boot ]] \
-  || { echo "error: plug in the live USB (OMARCHYLIVE) or an installed USB (OMARCHYBOOT)"; exit 1; }
+system_initrd=""
+[[ -f /boot/EFI/omarchy/initramfs.img ]] && system_initrd=/boot/EFI/omarchy/initramfs.img
+[[ -n $live || -n $boot || -n $system_initrd ]] \
+  || { echo "error: plug in the live USB, an installed USB, or run this on a machine with /boot/EFI/omarchy/initramfs.img"; exit 1; }
 
 mounted=()
 cleanup() {
@@ -77,8 +79,19 @@ if [[ -n $live ]]; then
   install -m644 "$repo_root/configs/usb-initcpio/install/omarchy-usb-wait" "$share/initcpio/install/omarchy-usb-wait"
   install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-asahi-hw.service" \
     "$mnt/etc/systemd/system/omarchy-mac-asahi-hw.service"
+  install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-quiet-console.service" \
+    "$mnt/etc/systemd/system/omarchy-mac-quiet-console.service"
+  systemctl --root="$mnt" enable omarchy-mac-quiet-console.service
+  install -d "$mnt/etc/systemd/system.conf.d" "$mnt/etc/sysctl.d"
+  install -m644 "$repo_root/configs/usb/rootfs/systemd-show-status.conf" \
+    "$mnt/etc/systemd/system.conf.d/show-status.conf"
+  install -m644 "$repo_root/configs/usb/rootfs/sysctl-quiet-console.conf" \
+    "$mnt/etc/sysctl.d/90-omarchy-quiet-console.conf"
   if [[ -d $iso_mnt/grub ]]; then
     install -m644 "$repo_root/configs/usb/grub.cfg" "$iso_mnt/grub/grub.cfg"
+  fi
+  if [[ -d $iso_mnt/EFI/BOOT ]]; then
+    install -m644 "$repo_root/configs/usb/grub.cfg" "$iso_mnt/EFI/BOOT/grub.cfg"
   fi
   echo "==> copied installer onto the live USB"
   echo "==> pacman --sysroot $mnt -Sy"
@@ -102,12 +115,27 @@ if [[ -n $iso ]]; then
   iso_mnt=$(mount_if_needed "$iso")
   cp -a "$out" "$iso_mnt/initramfs-linux-asahi.img"
   echo "==> wrote $iso_mnt/initramfs-linux-asahi.img"
+  live_out=/tmp/initramfs-omarchy-usb.img
+  echo "==> mkinitcpio live initrd (quiet console before switch_root)"
+  mkinitcpio -n \
+    -c "$repo_root/configs/usb-initcpio/mkinitcpio.conf" \
+    -D /usr/lib/initcpio \
+    -D "$repo_root/configs/usb-initcpio" \
+    -k "$kver" \
+    -g "$live_out"
+  cp -a "$live_out" "$iso_mnt/initramfs-omarchy-usb.img"
+  echo "==> wrote $iso_mnt/initramfs-omarchy-usb.img"
 fi
 
 if [[ -n $boot ]]; then
   boot_mnt=$(mount_if_needed "$boot")
   cp -a "$out" "$boot_mnt/initramfs-omarchy-usb-root.img"
   echo "==> wrote $boot_mnt/initramfs-omarchy-usb-root.img"
+fi
+
+if [[ -n $system_initrd ]]; then
+  cp -a "$out" "$system_initrd"
+  echo "==> wrote $system_initrd"
 fi
 
 # If a USB LUKS root is already unlocked, stop systemd asking again.
@@ -130,4 +158,4 @@ if [[ -n $root_mnt && -f $root_mnt/etc/crypttab ]]; then
 fi
 
 sync
-echo "==> Shutdown, boot the installed USB. Expect one branded unlock prompt."
+echo "==> done. Reboot to pick up the new initrd (notch/fnmode, Plymouth unlock)."

--- a/builder/build-rootfs.sh
+++ b/builder/build-rootfs.sh
@@ -148,6 +148,12 @@ cp -a "/usr/lib/modules/$kver" "$mnt/usr/lib/modules/"
 
 install -m644 "$repo_root/configs/usb/rootfs/issue" "$mnt/etc/issue"
 install -d "$mnt/etc/systemd/system"
+install -d "$mnt/etc/systemd/system.conf.d"
+install -m644 "$repo_root/configs/usb/rootfs/systemd-show-status.conf" \
+  "$mnt/etc/systemd/system.conf.d/show-status.conf"
+install -d "$mnt/etc/sysctl.d"
+install -m644 "$repo_root/configs/usb/rootfs/sysctl-quiet-console.conf" \
+  "$mnt/etc/sysctl.d/90-omarchy-quiet-console.conf"
 install -d "$mnt/usr/local/sbin"
 install -d "$mnt/usr/local/share/omarchy-mac-iso"
 install -m755 "$repo_root/configs/usb/rootfs/omarchy-mac-install" \
@@ -208,9 +214,12 @@ install -m644 "$repo_root/configs/usb/modprobe.d/asahi-notch.conf" \
   "$mnt/etc/modprobe.d/asahi-notch.conf"
 install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-asahi-hw.service" \
   "$mnt/etc/systemd/system/omarchy-mac-asahi-hw.service"
+install -m644 "$repo_root/configs/usb/rootfs/omarchy-mac-quiet-console.service" \
+  "$mnt/etc/systemd/system/omarchy-mac-quiet-console.service"
 
 systemctl --root="$mnt" enable omarchy-mac-usb-ready.service
 systemctl --root="$mnt" enable omarchy-mac-asahi-hw.service
+systemctl --root="$mnt" enable omarchy-mac-quiet-console.service
 systemctl --root="$mnt" enable NetworkManager.service
 systemctl --root="$mnt" enable speakersafetyd.service
 systemctl --root="$mnt" --global enable pipewire.socket pipewire-pulse.socket wireplumber.service 2>/dev/null || true

--- a/configs/usb-initcpio/hooks/omarchy-usb-live
+++ b/configs/usb-initcpio/hooks/omarchy-usb-live
@@ -71,8 +71,8 @@ run_hook() {
     hang "omarchy-usb-live: busybox is a symlink (switch_root would ENOENT)"
   fi
 
-  echo "==> OMARCHY_MAC_USB_READY" >/dev/console
-  echo "==> OMARCHY_MAC_USB_READY payload=$payload_dev marker=$(cat "$LIVE_MOUNT/$MARKER" 2>/dev/null)"
+  dmesg -n 1 >/dev/null 2>&1 || true
+  echo "1 4 1 3" >/proc/sys/kernel/printk 2>/dev/null || true
 
   # Asahi vendor firmware was extracted from the internal ESP by the asahi
   # hook. Carry it across switch_root so brcmfmac can associate in userspace.
@@ -91,7 +91,6 @@ run_hook() {
   mount --move /dev "$NEW_ROOT/dev" 2>/dev/null || mount --bind /dev "$NEW_ROOT/dev"
   mount --move /run "$NEW_ROOT/run" 2>/dev/null || true
 
-  echo "==> omarchy-usb-live: switch_root $NEW_ROOT /sbin/init" >/dev/console
   exec switch_root "$NEW_ROOT" /sbin/init
 
   hang "omarchy-usb-live: switch_root returned"

--- a/configs/usb-initcpio/install/omarchy-usb-wait
+++ b/configs/usb-initcpio/install/omarchy-usb-wait
@@ -3,6 +3,14 @@
 build() {
   add_binary /usr/bin/udevadm
   add_runscript
+  # show_notch/fnmode must be in the initrd. appledrm/hid_apple load
+  # there (kms/asahi); a rootfs modprobe.d file is too late.
+  local conf_dir
+  conf_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../usb/modprobe.d" && pwd)"
+  [[ -f $conf_dir/hid_apple.conf ]] &&
+    add_file "$conf_dir/hid_apple.conf" /etc/modprobe.d/hid_apple.conf
+  [[ -f $conf_dir/asahi-notch.conf ]] &&
+    add_file "$conf_dir/asahi-notch.conf" /etc/modprobe.d/asahi-notch.conf
 }
 
 help() {

--- a/configs/usb/grub.cfg
+++ b/configs/usb/grub.cfg
@@ -10,7 +10,7 @@ search --no-floppy --file /initramfs-omarchy-usb.img --set=root
 
 menuentry 'Omarchy Mac live (USB)' {
   echo 'GRUB is running from the USB ESP'
-  linux /vmlinuz-linux-asahi loglevel=3 quiet
+  linux /vmlinuz-linux-asahi quiet loglevel=0 systemd.show_status=0 rd.systemd.show_status=0 systemd.mask=plymouth-start.service systemd.mask=plymouth-quit-wait.service systemd.mask=ldconfig.service
   initrd /initramfs-omarchy-usb.img
 }
 

--- a/configs/usb/rootfs/omarchy-mac-esp.sh
+++ b/configs/usb/rootfs/omarchy-mac-esp.sh
@@ -62,9 +62,23 @@ esp_copy_unique_kernels() {
     "$esp_mnt/initramfs-omarchy-usb-root.img"
 }
 
+# linux line for an installed root. $2 is the LUKS UUID when encrypted.
+root_linux_args() {
+  local root_uuid=$1 luks_uuid=${2:-}
+  if [[ -n $luks_uuid ]]; then
+    printf 'root=UUID=%s rw rootflags=subvol=@ cryptdevice=UUID=%s:root:allow-discards loglevel=3 quiet splash' \
+      "$root_uuid" "$luks_uuid"
+  else
+    printf 'root=UUID=%s rw rootflags=subvol=@ loglevel=3 quiet splash' "$root_uuid"
+  fi
+}
+
 # Piggyback on an OS that already owns BOOTAA64.EFI (custom.cfg only).
+# $3 is the LUKS UUID when the new root is encrypted.
 write_piggyback_esp_grub() {
-  local esp_mnt=$1 root_uuid=$2
+  local esp_mnt=$1 root_uuid=$2 luks_uuid=${3:-}
+  local linux_args
+  linux_args=$(root_linux_args "$root_uuid" "$luks_uuid")
   mkdir -p "$esp_mnt/grub"
   esp_backup_existing "$esp_mnt" grub/custom.cfg || return 1
   esp_backup_existing "$esp_mnt" grub/grub.cfg || return 1
@@ -72,7 +86,7 @@ write_piggyback_esp_grub() {
   cat >"$esp_mnt/grub/custom.cfg" <<EOF
 menuentry 'Omarchy Mac (new root $root_uuid)' {
   search --no-floppy --file /omarchy-mac-root --set=root
-  linux /EFI/omarchy/vmlinuz root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3 quiet splash
+  linux /EFI/omarchy/vmlinuz $linux_args
   initrd /EFI/omarchy/initramfs.img
 }
 EOF
@@ -83,9 +97,12 @@ EOF
 }
 
 # Take over a UEFI-only System ESP: write BOOTAA64.EFI next to m1n1.
-# $3 is grub-embed-system.cfg. Does not touch m1n1/vendorfw/asahi.
+# $3 is grub-embed-system.cfg. $4 is the LUKS UUID when encrypted.
+# Does not touch m1n1/vendorfw/asahi.
 write_owned_esp_grub() {
-  local esp_mnt=$1 root_uuid=$2 embed_cfg=$3
+  local esp_mnt=$1 root_uuid=$2 embed_cfg=$3 luks_uuid=${4:-}
+  local linux_args
+  linux_args=$(root_linux_args "$root_uuid" "$luks_uuid")
   [[ -f $embed_cfg ]] || return 1
   command -v grub-mkstandalone >/dev/null || return 1
   mkdir -p "$esp_mnt/EFI/BOOT" "$esp_mnt/grub"
@@ -105,7 +122,7 @@ set default=0
 search --no-floppy --file /omarchy-mac-root --set=root
 
 menuentry 'Omarchy Mac' {
-  linux /EFI/omarchy/vmlinuz root=UUID=$root_uuid rw rootflags=subvol=@ loglevel=3 quiet splash
+  linux /EFI/omarchy/vmlinuz $linux_args
   initrd /EFI/omarchy/initramfs.img
 }
 EOF
@@ -118,14 +135,43 @@ EOF
     "boot/grub/grub.cfg=$embed_cfg" >/dev/null
 }
 
-# Print /dev/NAME of btrfs labelled OMARCHYROOT on $1 (disk NAME).
+# One field from an lsblk --pairs line. PARTLABEL contains the letters
+# LABEL, so a greedy .*LABEL= regex reads the wrong column.
+lsblk_pair_field() {
+  local line=$1 want=$2 rest key val
+  rest=$line
+  while [[ $rest =~ ^([A-Z]+)=\"([^\"]*)\"[[:space:]]*(.*)$ ]]; do
+    key=${BASH_REMATCH[1]}
+    val=${BASH_REMATCH[2]}
+    rest=${BASH_REMATCH[3]}
+    if [[ $key == "$want" ]]; then
+      printf '%s\n' "$val"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Print /dev/NAME of the Omarchy root on $1 (disk NAME). Matches a btrfs
+# labelled OMARCHYROOT, or a LUKS container labelled OMARCHYROOT / GPT
+# name "root" (mkpart). Asahi's own LUKS has neither — do not return it.
+# lsblk -l and -P cannot be combined (util-linux errors and prints nothing).
 existing_omarchy_root_on() {
-  local disk=$1 name fstype label
-  while read -r name fstype label; do
+  local disk=$1 line name fstype label partlabel
+  while IFS= read -r line; do
+    name=$(lsblk_pair_field "$line" NAME) || continue
+    fstype=$(lsblk_pair_field "$line" FSTYPE) || fstype=
+    label=$(lsblk_pair_field "$line" LABEL) || label=
+    partlabel=$(lsblk_pair_field "$line" PARTLABEL) || partlabel=
     [[ $name == "$disk" ]] && continue
-    [[ $fstype == btrfs && $label == OMARCHYROOT ]] || continue
-    printf '/dev/%s\n' "$name"
-    return 0
-  done < <(lsblk -ln -o NAME,FSTYPE,LABEL "/dev/$disk" 2>/dev/null)
+    if [[ $fstype == btrfs && $label == OMARCHYROOT ]]; then
+      printf '/dev/%s\n' "$name"
+      return 0
+    fi
+    if [[ $fstype == crypto_LUKS && ( $label == OMARCHYROOT || $partlabel == root ) ]]; then
+      printf '/dev/%s\n' "$name"
+      return 0
+    fi
+  done < <(lsblk -n -P -o NAME,FSTYPE,LABEL,PARTLABEL "/dev/$disk" 2>/dev/null)
   return 1
 }

--- a/configs/usb/rootfs/omarchy-mac-install
+++ b/configs/usb/rootfs/omarchy-mac-install
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Clone this live USB, wipe-install a USB, or install into GPT free space
 # (never mklabel a disk that already has Apple partitions). LUKS is offered
-# on wipe-USB only; free-space and replace-existing stay unencrypted.
+# on wipe-USB, free-space, and replace-existing.
 set -euo pipefail
 
 fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+retry() { printf '==> %s\n' "$*" >&2; }
 
 # Wall time of the copy/personalize, not the gum questions.
 install_start=0
@@ -271,23 +272,169 @@ require_graphical_payload() {
     || fail "no Hyprland/omarchy wayland session in this payload — rebuild with --usb --rootfs"
 }
 
-# Ask before dd. A gum prompt after 30 minutes of copy dies if the lid
-# closes or the TTY goes away (Input/output error).
+# Ask before the payload copy. A gum prompt after a long copy dies if
+# the lid closes or the TTY goes away (Input/output error). Validation
+# failures re-prompt; they must not exit the installer.
 ask_desktop_user() {
   local pass2 reserved='^(root|bin|daemon|nobody|dbus|alpm|git|avahi|polkitd|sddm|uuidd)$'
   if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
     desktop_user=dryrun
     desktop_pass=dryrun
+    desktop_hostname=omarchy
     return 0
   fi
-  desktop_user=$(gum input --placeholder "Alphanumeric without spaces (like dhh)" --header "Username for the installed desktop")
-  [[ -n $desktop_user ]] || fail "cancelled"
-  [[ $desktop_user =~ ^[a-z_][a-z0-9_-]*$ ]] || fail "invalid username"
-  [[ $desktop_user =~ $reserved ]] && fail "username $desktop_user is reserved"
-  desktop_pass=$(gum input --password --placeholder "Used for the desktop user" --header "Password")
-  [[ -n $desktop_pass ]] || fail "cancelled"
-  pass2=$(gum input --password --placeholder "Must match the password you just typed" --header "Confirm password")
-  [[ $desktop_pass == "$pass2" ]] || fail "passwords do not match"
+  while true; do
+    desktop_user=$(gum input --placeholder "Alphanumeric without spaces (like dhh)" --header "Username for the installed desktop")
+    if [[ -z $desktop_user ]]; then
+      retry "username is required"
+      continue
+    fi
+    if [[ ! $desktop_user =~ ^[a-z_][a-z0-9_-]*$ ]]; then
+      retry "username must be alphanumeric without spaces (like dhh)"
+      continue
+    fi
+    if [[ $desktop_user =~ $reserved ]]; then
+      retry "username $desktop_user is reserved"
+      continue
+    fi
+    break
+  done
+  while true; do
+    desktop_pass=$(gum input --password --placeholder "Used for the desktop user" --header "Password")
+    if [[ -z $desktop_pass ]]; then
+      retry "password is required"
+      continue
+    fi
+    pass2=$(gum input --password --placeholder "Must match the password you just typed" --header "Confirm password")
+    if [[ $desktop_pass != "$pass2" ]]; then
+      retry "passwords do not match — try again"
+      continue
+    fi
+    break
+  done
+  ask_hostname
+}
+
+# Same rules as install/provisioning/setup-form.sh. Empty → omarchy.
+ask_hostname() {
+  local name
+  while true; do
+    name=$(gum input --placeholder "Letters, digits, and dashes (or return for 'omarchy')" --header "Hostname")
+    if [[ -z $name ]]; then
+      desktop_hostname=omarchy
+      return 0
+    fi
+    if [[ $name =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$ ]]; then
+      desktop_hostname=$name
+      return 0
+    fi
+    retry "hostname must be 1-63 letters, digits, or dashes"
+  done
+}
+
+write_installed_hostname() {
+  local root_mnt=$1
+  printf '%s\n' "$desktop_hostname" >"$root_mnt/etc/hostname"
+  cat >"$root_mnt/etc/hosts" <<EOF
+127.0.0.1 localhost
+::1 localhost
+127.0.1.1 $desktop_hostname
+EOF
+}
+
+# Sets encrypt_root=1 when the user keeps the default. Same password as
+# the desktop user. Caller must have asked for that password already.
+ask_encrypt_root() {
+  encrypt_root=0
+  if gum confirm --default --affirmative "Encrypt" --negative "No encryption" \
+    "Encrypt the disk? Recommended. Same password as the desktop user."; then
+    encrypt_root=1
+    command -v cryptsetup >/dev/null \
+      || fail "cryptsetup not found — rebuild with --usb --rootfs"
+  fi
+}
+
+# Same review as the x86 ISO configurator: table of every choice, then
+# "Does this look right?" No, change it re-asks user + encryption.
+confirm_install_choices() {
+  local action_label=$1 target_label=$2
+  local stars encrypt_label
+  while true; do
+    stars=$(printf '%*s' "${#desktop_pass}" '' | tr ' ' '*')
+    if (( encrypt_root == 1 )); then
+      encrypt_label="Yes (same password)"
+    else
+      encrypt_label="No"
+    fi
+    echo
+    printf 'Field,Value\nAction,%s\nTarget,%s\nUsername,%s\nPassword,%s\nHostname,%s\nEncryption,%s\n' \
+      "$action_label" "$target_label" "$desktop_user" "$stars" "$desktop_hostname" "$encrypt_label" |
+      gum table -s "," -p
+    echo
+    if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
+      printf 'dry-run: Does this look right? user=%s host=%s encrypt=%s target=%s\n' \
+        "$desktop_user" "$desktop_hostname" "$encrypt_label" "$target_label"
+      return 0
+    fi
+    if gum confirm --affirmative "Yes, install" --negative "No, change it" \
+      "Does this look right?"; then
+      return 0
+    fi
+    ask_desktop_user
+    ask_encrypt_root
+  done
+}
+
+# Live payload @ (used files). Prefer the overlay lowerdir so tmpfs
+# writes from the live session are not copied.
+live_payload_mount() {
+  if [[ -d /run/omarchy-root && -e /run/omarchy-root/omarchy-mac-live-ok ]]; then
+    printf '%s\n' /run/omarchy-root
+    return 0
+  fi
+  local mnt
+  mnt=$(findmnt -n -o TARGET "$live_partition" 2>/dev/null | awk 'NR==1 { print }')
+  if [[ -n $mnt && -e $mnt/omarchy-mac-live-ok ]]; then
+    printf '%s\n' "$mnt"
+    return 0
+  fi
+  return 1
+}
+
+# Used size of the live tree, not the 8GiB payload partition.
+live_payload_used_bytes() {
+  local src bytes
+  src=$(live_payload_mount) || fail "live payload @ is not mounted"
+  bytes=$(du -sb "$src" | awk '{ print $1 }')
+  [[ $bytes =~ ^[0-9]+$ ]] || fail "could not measure live tree size"
+  printf '%s\n' "$bytes"
+}
+
+# Fresh btrfs with @ / @home / @log. Mounts @ on $2.
+format_installed_btrfs() {
+  local root_dev=$1 root_mnt=$2 top
+  printf '==> mkfs.btrfs %s (OMARCHYROOT)\n' "$root_dev"
+  wipefs -a "$root_dev" >/dev/null 2>&1 || true
+  mkfs.btrfs -q -L OMARCHYROOT --csum crc32c "$root_dev"
+  top=$(mktemp -d)
+  mount "$root_dev" "$top"
+  btrfs subvolume create "$top/@" >/dev/null
+  btrfs subvolume create "$top/@home" >/dev/null
+  btrfs subvolume create "$top/@log" >/dev/null
+  umount "$top"
+  rmdir "$top"
+  mount -o subvol=@ "$root_dev" "$root_mnt"
+}
+
+# Copy used files only. Not a dd of empty payload space.
+copy_live_payload() {
+  local dest=$1 src
+  src=$(live_payload_mount) || fail "live payload @ is not mounted"
+  printf '==> copying %s of live tree onto the new root\n' "$(du -sh "$src" | cut -f1)"
+  tar -C "$src" --one-file-system --xattrs --acls --numeric-owner \
+    --exclude='./etc/pacman.d/gnupg/S.*' --warning=no-file-ignored -cf - . \
+    | tar -C "$dest" --xattrs --acls --numeric-owner --warning=no-file-ignored -xf -
+  sync
 }
 
 # Same default as install/user/theme.sh. Seed at install so the first
@@ -319,6 +466,7 @@ seed_tokyo_night() {
 
   if chroot "$root_mnt" runuser -u "$user" -- env \
       HOME=/home/"$user" USER="$user" LOGNAME="$user" \
+      XDG_RUNTIME_DIR=/tmp \
       OMARCHY_PATH=/usr/share/omarchy \
       OMARCHY_SETUP_CONTEXT=iso-chroot \
       OMARCHY_THEME_HEADLESS=1 \
@@ -402,30 +550,19 @@ install_persistent_root() {
   require_graphical_payload
   ask_desktop_user
 
-  payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
+  payload_bytes=$(live_payload_used_bytes)
   min_bytes=$(( ESP_MIB * 1024 * 1024 + payload_bytes + 64 * 1024 * 1024 ))
   pick_target_disk "$min_bytes"
-  printf '==> confirm DESTROY of %s (arrow keys, then enter)\n' "$target_dev"
-  gum confirm \
-    "DESTROY $target_dev (${choice#*  }) and install a persistent USB root (no overlay)?" \
-    || fail "cancelled"
-  printf '==> confirmed\n'
-  if gum confirm --default --affirmative "Encrypt" --negative "No encryption" \
-    "Encrypt the disk? Recommended. Same password as the desktop user."; then
-    encrypt_root=1
-    command -v cryptsetup >/dev/null \
-      || fail "cryptsetup not found — rebuild with --usb --rootfs"
-  fi
+  ask_encrypt_root
+  confirm_install_choices "Wipe USB and install" \
+    "$target_dev ($(lsblk -dn -o SIZE "$target_dev")) — DESTROY every partition"
 
   mark_install_start
   source_esp=$(esp_partition_on "$live_disk" || true)
   [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
 
   unmount_disk "$target_dev"
-  if (( running_from_this_live_usb == 1 )); then
-    unmount_disk "$source_dev" 1
-  fi
-  sync
+  # Keep the live payload mounted; we copy files, not dd the block device.
 
   printf '==> partitioning %s (512MiB ESP + btrfs root)\n' "$target_dev"
   wipefs -a "$target_dev" 2>/dev/null || true
@@ -446,34 +583,18 @@ install_persistent_root() {
   root_dev=$root_part
   if (( encrypt_root == 1 )); then
     printf '==> luksFormat %s\n' "$root_part"
-    printf '%s' "$desktop_pass" | cryptsetup luksFormat --type luks2 --batch-mode --key-file=- "$root_part"
+    printf '%s' "$desktop_pass" | cryptsetup luksFormat --type luks2 --label OMARCHYROOT --batch-mode --key-file=- "$root_part"
     printf '%s' "$desktop_pass" | cryptsetup open --key-file=- "$root_part" root
     root_dev=/dev/mapper/root
     luks_uuid=$(blkid -s UUID -o value "$root_part")
     [[ -n $luks_uuid ]] || fail "no UUID on LUKS container $root_part"
   fi
 
-  printf '==> copying payload %s -> %s\n' "$live_partition" "$root_dev"
-  dd if="$live_partition" of="$root_dev" bs=4M status=progress conv=fsync oflag=sync
-  sync
-  partprobe "$target_dev" 2>/dev/null || true
-  command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
-
   root_mnt=$(mktemp -d)
-  mount -o subvol=@ "$root_dev" "$root_mnt"
-  printf '==> btrfs resize max on %s\n' "$root_dev"
-  btrfs filesystem resize max "$root_mnt"
-  btrfs filesystem label "$root_mnt" OMARCHYROOT
-  umount "$root_mnt"
-
-  if command -v btrfs >/dev/null; then
-    btrfs device scan --forget "$root_dev" || true
-  fi
-  btrfstune -f -u "$root_dev"
-  mount -o subvol=@ "$root_dev" "$root_mnt"
-
+  format_installed_btrfs "$root_dev" "$root_mnt"
+  copy_live_payload "$root_mnt"
   root_uuid=$(blkid -s UUID -o value "$root_dev")
-  [[ -n $root_uuid ]] || fail "no UUID on $root_dev after btrfstune"
+  [[ -n $root_uuid ]] || fail "no UUID on $root_dev"
 
   printf 'UUID=%s / btrfs subvol=@,compress=zstd:1 0 0\n' "$root_uuid" >"$root_mnt/etc/fstab"
   printf 'UUID=%s /home btrfs subvol=@home,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
@@ -481,7 +602,7 @@ install_persistent_root() {
   if (( encrypt_root == 1 )); then
     printf 'root UUID=%s none luks,discard,x-initrd.attach\n' "$luks_uuid" >"$root_mnt/etc/crypttab"
   fi
-  printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
+  write_installed_hostname "$root_mnt"
   cat >"$root_mnt/etc/issue" <<'EOF'
 Omarchy Mac (installed). SDDM autologin.
 EOF
@@ -570,7 +691,7 @@ EOF
 # or own (UEFI-only: write BOOTAA64.EFI). Never touches m1n1/vendorfw/asahi.
 # Prints "piggyback" or "own" to stdout. Caller holds the root mount.
 apply_system_esp_bootloader() {
-  local esp_part=$1 root_uuid=$2 source_esp=$3
+  local esp_part=$1 root_uuid=$2 source_esp=$3 luks_uuid=${4:-}
   local esp_mnt live_esp_mnt
   local esp_mounted_by_us=0 live_esp_mounted_by_us=0
   local before_efi after_efi before_prot after_prot
@@ -603,14 +724,14 @@ apply_system_esp_bootloader() {
   fi
 
   if esp_has_bootloader "$esp_mnt"; then
-    write_piggyback_esp_grub "$esp_mnt" "$root_uuid"
+    write_piggyback_esp_grub "$esp_mnt" "$root_uuid" "$luks_uuid"
     after_efi=$(sha256sum "$esp_mnt/EFI/BOOT/BOOTAA64.EFI" 2>/dev/null || true)
     [[ $before_efi == "$after_efi" ]] || fail "BOOTAA64.EFI changed — aborting"
     mode=piggyback
   else
     command -v grub-mkstandalone >/dev/null \
       || fail "grub-mkstandalone not found — rebuild with --usb --rootfs (grub)"
-    write_owned_esp_grub "$esp_mnt" "$root_uuid" "$embed_cfg" \
+    write_owned_esp_grub "$esp_mnt" "$root_uuid" "$embed_cfg" "$luks_uuid" \
       || fail "could not write System ESP GRUB"
     [[ -f $esp_mnt/EFI/BOOT/BOOTAA64.EFI ]] || fail "BOOTAA64.EFI missing after own-mode write"
     [[ -f $esp_mnt/omarchy-mac-root ]] || fail "omarchy-mac-root marker missing"
@@ -631,16 +752,16 @@ install_into_free_space() {
   local payload_bytes min_bytes name size model tran bytes
   local hole_start hole_size hole_end
   local before_names before_apple backup
-  local root_part root_mnt esp_part
-  local root_uuid esp_uuid
-  local payload_mnt esp_mode
+  local root_part root_dev root_mnt esp_part
+  local root_uuid esp_uuid luks_uuid=""
+  local esp_mode encrypt_root=0
   local created_parts=()
 
   command -v parted >/dev/null || fail "parted not found"
   require_graphical_payload
   ask_desktop_user
 
-  payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
+  payload_bytes=$(live_payload_used_bytes)
   min_bytes=$(( payload_bytes + 64 * 1024 * 1024 ))
   min_mib=$(( (min_bytes + 1024 * 1024 - 1) / (1024 * 1024) ))
 
@@ -676,10 +797,9 @@ install_into_free_space() {
 
   printf '==> selected %s hole %sMiB-%sMiB (%sMiB)\n' \
     "$target_dev" "$hole_start" "$hole_end" "$hole_size"
-  printf '==> confirm (arrow keys, then enter)\n'
-  gum confirm \
-    "Create ONE new partition on $target_dev from ${hole_start}MiB to ${hole_end}MiB. APFS/iBoot/Recovery and all existing partitions stay. No mklabel, no LUKS. Continue?" \
-    || fail "cancelled"
+  ask_encrypt_root
+  confirm_install_choices "Install into free space" \
+    "$target_dev ${hole_start}MiB-${hole_end}MiB — existing partitions stay"
 
   if disk_has_apple_partitions "$target_name" || disk_is_nvme "$target_name"; then
     [[ -z ${OMARCHY_INSTALL_DRY_RUN:-} ]] || true
@@ -688,6 +808,7 @@ install_into_free_space() {
   if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
     printf 'dry-run: parted %s mkpart root btrfs %sMiB %sMiB\n' \
       "$target_dev" "$hole_start" "$hole_end"
+    (( encrypt_root == 1 )) && printf 'dry-run: luksFormat the new partition\n'
     printf 'dry-run: would NOT mklabel or wipefs\n'
     return 0
   fi
@@ -697,14 +818,6 @@ install_into_free_space() {
   [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
   esp_part=$(existing_esp_on "$target_name" || true)
   [[ -n $esp_part ]] || fail "$target_dev has no ESP; will not create one next to APFS"
-
-  # Do not dd a mounted payload (btrfs csum corruption). Overlay lowerdir stays.
-  if (( running_from_this_live_usb != 1 )); then
-    payload_mnt=$(findmnt -n -o TARGET "$live_partition" || true)
-    if [[ -n $payload_mnt ]]; then
-      umount "$payload_mnt" || fail "could not unmount $payload_mnt before dd"
-    fi
-  fi
 
   backup=$(mktemp /tmp/omarchy-gpt-${target_name}.XXXXXX)
   if command -v sfdisk >/dev/null; then
@@ -745,52 +858,48 @@ install_into_free_space() {
   created_parts+=("$root_part")
   printf '==> new partition %s\n' "$root_part"
 
-  printf '==> copying payload %s -> %s\n' "$live_partition" "$root_part"
-  dd if="$live_partition" of="$root_part" bs=4M status=progress conv=fsync oflag=sync
-  sync
-  partprobe "$target_dev" 2>/dev/null || true
-  command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
-
-  # dd copies the live UUID; udisks will remount it. Unique UUID first.
-  for _ in 1 2 3 4 5 6; do
-    m=$(findmnt -n -o TARGET "$root_part" || true)
-    [[ -z $m ]] && break
-    umount "$m" || umount -l "$m" || true
-    sleep 0.5
-  done
-  findmnt -n "$root_part" >/dev/null && fail "$root_part still mounted; cannot btrfstune"
-  if command -v btrfs >/dev/null; then
-    btrfs device scan --forget "$root_part" || true
+  root_dev=$root_part
+  if (( encrypt_root == 1 )); then
+    printf '==> luksFormat %s\n' "$root_part"
+    printf '%s' "$desktop_pass" | cryptsetup luksFormat --type luks2 --label OMARCHYROOT --batch-mode --key-file=- "$root_part"
+    printf '%s' "$desktop_pass" | cryptsetup open --key-file=- "$root_part" root
+    root_dev=/dev/mapper/root
+    luks_uuid=$(blkid -s UUID -o value "$root_part")
+    [[ -n $luks_uuid ]] || fail "no UUID on LUKS container $root_part"
   fi
-  btrfstune -f -u "$root_part"
 
   root_mnt=$(mktemp -d)
-  mount -o subvol=@ "$root_part" "$root_mnt"
-  btrfs filesystem resize max "$root_mnt"
-  btrfs filesystem label "$root_mnt" OMARCHYROOT
-  root_uuid=$(blkid -s UUID -o value "$root_part")
-  [[ -n $root_uuid ]] || fail "no UUID on $root_part"
+  format_installed_btrfs "$root_dev" "$root_mnt"
+  copy_live_payload "$root_mnt"
+  root_uuid=$(blkid -s UUID -o value "$root_dev")
+  [[ -n $root_uuid ]] || fail "no UUID on $root_dev"
 
   printf 'UUID=%s / btrfs subvol=@,compress=zstd:1 0 0\n' "$root_uuid" >"$root_mnt/etc/fstab"
   printf 'UUID=%s /home btrfs subvol=@home,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
   printf 'UUID=%s /var/log btrfs subvol=@log,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
-  printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
+  if (( encrypt_root == 1 )); then
+    printf 'root UUID=%s none luks,discard,x-initrd.attach\n' "$luks_uuid" >"$root_mnt/etc/crypttab"
+  fi
+  write_installed_hostname "$root_mnt"
   cat >"$root_mnt/etc/issue" <<'EOF'
 Omarchy Mac (installed). SDDM autologin.
 EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
 
-  esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp")
+  esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp" "$luks_uuid")
 
   esp_uuid=$(blkid -s UUID -o value "$esp_part")
   printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"
 
-  personalize_graphical_session "$root_mnt" "$root_part"
+  personalize_graphical_session "$root_mnt" "$root_dev"
 
   sync
   umount "$root_mnt"
   rmdir "$root_mnt" 2>/dev/null || true
+  if (( encrypt_root == 1 )); then
+    cryptsetup close root
+  fi
 
   printf '==> done. Did not mklabel %s. New root %s UUID=%s\n' \
     "$target_dev" "$root_part" "$root_uuid"
@@ -808,14 +917,16 @@ EOF
 # partition node so two roots (NVMe hole vs USB stick) cannot be confused.
 existing_root_row() {
   local root_part=$1
-  local disk size model where
+  local disk size model where fstype extra=""
   disk=$(lsblk -no PKNAME "$root_part")
   size=$(lsblk -dn -o SIZE "$root_part")
   model=$(lsblk -dn -o MODEL "/dev/$disk" | tr -s ' ')
+  fstype=$(lsblk -dn -o FSTYPE "$root_part")
+  [[ $fstype == crypto_LUKS ]] && extra="encrypted, "
   if disk_is_nvme "$disk"; then
-    where="internal NVMe — other partitions stay"
+    where="internal NVMe — ${extra}other partitions stay"
   else
-    where="USB stick — ${model:-usb}"
+    where="USB stick — ${extra}${model:-usb}"
   fi
   printf '%s  %s  %s\n' "$root_part" "$size" "$where"
 }
@@ -824,31 +935,36 @@ existing_root_row() {
 # no wipefs of the disk. The 46G NVMe hole (p7) is this path: the GPT gap
 # is already a partition, so free-space install would find nothing.
 install_over_existing_root() {
-  local name size
+  local name size bytes found_any=0
   local candidates=()
-  local source_esp esp_part root_part root_mnt
-  local root_uuid esp_uuid payload_bytes payload_mnt
-  local before_apple after_apple backup m esp_mode
+  local source_esp esp_part root_part root_dev root_mnt
+  local root_uuid esp_uuid luks_uuid="" payload_bytes
+  local before_apple after_apple backup m esp_mode encrypt_root=0
 
   command -v parted >/dev/null || fail "parted not found"
   require_graphical_payload
 
-  payload_bytes=$(lsblk -dn -b -o SIZE "$live_partition")
+  payload_bytes=$(live_payload_used_bytes)
   source_esp=$(esp_partition_on "$live_disk" || true)
   [[ -n $source_esp ]] || fail "no ESP on the live USB $source_dev"
 
+  found_any=0
   while read -r name; do
     [[ $name == "$live_disk" ]] && continue
     existing_esp_on "$name" >/dev/null || continue
     root_part=$(existing_omarchy_root_on "$name" || true)
     [[ -n $root_part ]] || continue
     [[ $root_part == "$live_partition" ]] && continue
+    found_any=1
     bytes=$(lsblk -dn -b -o SIZE "$root_part")
     (( bytes >= payload_bytes + 64 * 1024 * 1024 )) || continue
     candidates+=("$(existing_root_row "$root_part")")
   done < <(lsblk -dn -o NAME)
 
-  (( ${#candidates[@]} > 0 )) || fail "no existing OMARCHYROOT is large enough (need payload + 64MiB). Install into free space first, or pick a bigger partition."
+  if (( found_any == 0 )); then
+    fail "no existing Omarchy root found (btrfs OMARCHYROOT or an encrypted root). Install into free space first."
+  fi
+  (( ${#candidates[@]} > 0 )) || fail "no existing Omarchy root is large enough (need the live tree + 64MiB)."
 
   choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Which Omarchy root partition should be replaced? Not the ESP.")
   [[ -n $choice ]] || fail "cancelled"
@@ -863,25 +979,19 @@ install_over_existing_root() {
 
   printf '==> selected %s on %s (%s)\n' "$root_part" "$target_dev" "$size"
   ask_desktop_user
-  printf '==> confirm (arrow keys, then enter)\n'
-  gum confirm \
-    "Replace ONLY $root_part ($size) on $target_dev. Not the ESP. Other partitions stay. No mklabel, no mkpart, no LUKS. Continue?" \
-    || fail "cancelled"
+  ask_encrypt_root
+  confirm_install_choices "Replace existing Omarchy root" \
+    "$root_part ($size) on $target_dev — ESP and other partitions stay"
 
   if [[ ${OMARCHY_INSTALL_DRY_RUN:-} == 1 ]]; then
-    printf 'dry-run: dd %s -> %s then btrfstune -u (no mkpart, no mklabel)\n' \
-      "$live_partition" "$root_part"
+    printf 'dry-run: format %s and copy the live tree (no mkpart, no mklabel)\n' \
+      "$root_part"
+    (( encrypt_root == 1 )) && printf 'dry-run: luksFormat %s first\n' "$root_part"
     printf 'dry-run: would NOT mklabel, mkpart, or wipefs\n'
     return 0
   fi
 
   mark_install_start
-  if (( running_from_this_live_usb != 1 )); then
-    payload_mnt=$(findmnt -n -o TARGET "$live_partition" || true)
-    if [[ -n $payload_mnt ]]; then
-      umount "$payload_mnt" || fail "could not unmount $payload_mnt before dd"
-    fi
-  fi
 
   backup=$(mktemp /tmp/omarchy-gpt-${target_name}.XXXXXX)
   if command -v sfdisk >/dev/null; then
@@ -896,13 +1006,17 @@ install_over_existing_root() {
     umount "$m" || umount -l "$m" || true
     sleep 0.5
   done
-  findmnt -n "$root_part" >/dev/null && fail "$root_part still mounted; cannot dd"
+  findmnt -n "$root_part" >/dev/null && fail "$root_part still mounted; cannot format"
 
-  printf '==> copying payload %s -> %s\n' "$live_partition" "$root_part"
-  dd if="$live_partition" of="$root_part" bs=4M status=progress conv=fsync oflag=sync
-  sync
-  partprobe "$target_dev" 2>/dev/null || true
-  command -v udevadm >/dev/null && udevadm settle --timeout=5 || true
+  root_dev=$root_part
+  if (( encrypt_root == 1 )); then
+    printf '==> luksFormat %s\n' "$root_part"
+    printf '%s' "$desktop_pass" | cryptsetup luksFormat --type luks2 --label OMARCHYROOT --batch-mode --key-file=- "$root_part"
+    printf '%s' "$desktop_pass" | cryptsetup open --key-file=- "$root_part" root
+    root_dev=/dev/mapper/root
+    luks_uuid=$(blkid -s UUID -o value "$root_part")
+    [[ -n $luks_uuid ]] || fail "no UUID on LUKS container $root_part"
+  fi
 
   after_apple=$(apple_partition_snapshot "$target_dev")
   if [[ $before_apple != "$after_apple" ]]; then
@@ -911,45 +1025,38 @@ install_over_existing_root() {
     exit 1
   fi
 
-  for _ in 1 2 3 4 5 6; do
-    m=$(findmnt -n -o TARGET "$root_part" || true)
-    [[ -z $m ]] && break
-    umount "$m" || umount -l "$m" || true
-    sleep 0.5
-  done
-  findmnt -n "$root_part" >/dev/null && fail "$root_part still mounted; cannot btrfstune"
-  if command -v btrfs >/dev/null; then
-    btrfs device scan --forget "$root_part" || true
-  fi
-  btrfstune -f -u "$root_part"
-
   root_mnt=$(mktemp -d)
-  mount -o subvol=@ "$root_part" "$root_mnt"
-  btrfs filesystem resize max "$root_mnt"
-  btrfs filesystem label "$root_mnt" OMARCHYROOT
-  root_uuid=$(blkid -s UUID -o value "$root_part")
-  [[ -n $root_uuid ]] || fail "no UUID on $root_part"
+  format_installed_btrfs "$root_dev" "$root_mnt"
+  copy_live_payload "$root_mnt"
+  root_uuid=$(blkid -s UUID -o value "$root_dev")
+  [[ -n $root_uuid ]] || fail "no UUID on $root_dev"
 
   printf 'UUID=%s / btrfs subvol=@,compress=zstd:1 0 0\n' "$root_uuid" >"$root_mnt/etc/fstab"
   printf 'UUID=%s /home btrfs subvol=@home,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
   printf 'UUID=%s /var/log btrfs subvol=@log,compress=zstd:1 0 0\n' "$root_uuid" >>"$root_mnt/etc/fstab"
-  printf 'omarchy-mac\n' >"$root_mnt/etc/hostname"
+  if (( encrypt_root == 1 )); then
+    printf 'root UUID=%s none luks,discard,x-initrd.attach\n' "$luks_uuid" >"$root_mnt/etc/crypttab"
+  fi
+  write_installed_hostname "$root_mnt"
   cat >"$root_mnt/etc/issue" <<'EOF'
 Omarchy Mac (installed). SDDM autologin.
 EOF
   rm -f "$root_mnt/omarchy-mac-overlay-write"
   : >"$root_mnt/etc/machine-id"
 
-  esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp")
+  esp_mode=$(apply_system_esp_bootloader "$esp_part" "$root_uuid" "$source_esp" "$luks_uuid")
 
   esp_uuid=$(blkid -s UUID -o value "$esp_part")
   printf 'UUID=%s /boot vfat defaults,fmask=0133,dmask=0022 0 2\n' "$esp_uuid" >>"$root_mnt/etc/fstab"
 
-  personalize_graphical_session "$root_mnt" "$root_part"
+  personalize_graphical_session "$root_mnt" "$root_dev"
 
   sync
   umount "$root_mnt"
   rmdir "$root_mnt" 2>/dev/null || true
+  if (( encrypt_root == 1 )); then
+    cryptsetup close root
+  fi
 
   printf '==> done. Did not mklabel or mkpart %s. Replaced %s UUID=%s\n' \
     "$target_dev" "$root_part" "$root_uuid"
@@ -978,10 +1085,11 @@ install_grub_for_existing_root() {
     existing_esp_on "$name" >/dev/null || continue
     root_part=$(existing_omarchy_root_on "$name" || true)
     [[ -n $root_part ]] || continue
+    [[ $(lsblk -dn -o FSTYPE "$root_part") == crypto_LUKS ]] && continue
     candidates+=("$(existing_root_row "$root_part")")
   done < <(lsblk -dn -o NAME)
 
-  (( ${#candidates[@]} > 0 )) || fail "no disk has both an ESP and an OMARCHYROOT (install into free space first)"
+  (( ${#candidates[@]} > 0 )) || fail "no unencrypted Omarchy root found. Reinstall an encrypted root, or install into free space first."
 
   choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Write GRUB for which Omarchy root? Filesystem stays.")
   [[ -n $choice ]] || fail "cancelled"

--- a/configs/usb/rootfs/omarchy-mac-quiet-console.service
+++ b/configs/usb/rootfs/omarchy-mac-quiet-console.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Quiet live console printk before firmware loads
+DefaultDependencies=no
+Before=sysinit.target systemd-udevd.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c 'dmesg -n 1; echo 1 4 1 3 >/proc/sys/kernel/printk'
+
+[Install]
+WantedBy=sysinit.target

--- a/configs/usb/rootfs/sysctl-quiet-console.conf
+++ b/configs/usb/rootfs/sysctl-quiet-console.conf
@@ -1,0 +1,3 @@
+# Asahi wifi/bluetooth firmware printk is KERN_ERR and paints the
+# live console even with quiet. Keep the console at crit and below.
+kernel.printk = 3 4 1 3

--- a/configs/usb/rootfs/systemd-show-status.conf
+++ b/configs/usb/rootfs/systemd-show-status.conf
@@ -1,0 +1,3 @@
+[Manager]
+ShowStatus=no
+LogLevel=err

--- a/test/esp-grub
+++ b/test/esp-grub
@@ -95,11 +95,29 @@ check "piggyback custom.cfg loads EFI/omarchy/vmlinuz" \
   "grep -q '/EFI/omarchy/vmlinuz' '$pig/grub/custom.cfg'"
 check "piggyback custom.cfg names the new UUID" \
   "grep -q 'root=UUID=11111111-2222-3333-4444-555555555555' '$pig/grub/custom.cfg'"
+check "piggyback without LUKS has no cryptdevice" \
+  "! grep -q cryptdevice '$pig/grub/custom.cfg'"
+write_piggyback_esp_grub "$pig" "11111111-2222-3333-4444-555555555555" \
+  "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+check "piggyback with LUKS adds cryptdevice" \
+  "grep -q 'cryptdevice=UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:root:allow-discards' '$pig/grub/custom.cfg'"
 check "piggyback sources custom.cfg from grub.cfg" "grep -q custom.cfg '$pig/grub/grub.cfg'"
 check "piggyback leaves m1n1 hash unchanged" "[[ '$before_pig' == '$after_pig' ]]"
 check "esp_has_bootloader is true for piggyback ESP" "[[ -f '$pig/EFI/BOOT/BOOTAA64.EFI' ]]"
 check "esp_has_bootloader is false on an empty ESP dir" \
   "[[ ! -f '$work/empty-esp/EFI/BOOT/BOOTAA64.EFI' ]]"
+
+p7_pairs='NAME="nvme0n1p7" FSTYPE="crypto_LUKS" LABEL="" PARTLABEL="root"'
+asahi_pairs='NAME="nvme0n1p5" FSTYPE="crypto_LUKS" LABEL="" PARTLABEL=""'
+esp_sh="${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
+check "lsblk pairs keep an empty LABEL off PARTLABEL" \
+  "source '$esp_sh'; [[ -z \$(lsblk_pair_field '$p7_pairs' LABEL) ]]"
+check "lsblk pairs read GPT name root on the encrypted hole" \
+  "source '$esp_sh'; [[ \$(lsblk_pair_field '$p7_pairs' PARTLABEL) == root ]]"
+check "lsblk pairs read crypto_LUKS on the encrypted hole" \
+  "source '$esp_sh'; [[ \$(lsblk_pair_field '$p7_pairs' FSTYPE) == crypto_LUKS ]]"
+check "lsblk pairs leave Asahi LUKS unnamed" \
+  "source '$esp_sh'; [[ -z \$(lsblk_pair_field '$asahi_pairs' PARTLABEL) ]]"
 
 if (( failures > 0 )); then
   echo "${failures} esp-grub test failure(s)"

--- a/test/unit
+++ b/test/unit
@@ -97,7 +97,9 @@ check "install script refuses Apple partition GUIDs" grep -q 7c3457ef \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-disk.sh"
 check "install script copies through last partition not whole disk" grep -q iflag=count_bytes \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
-check "install script unmounts the live USB before dd" grep -q 'unmount_disk "$source_dev"' \
+check "clone unmounts the live USB before dd" grep -q 'unmount_disk "$source_dev"' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "clone still dd's the live USB through last partition" grep -q 'dd if="$source_dev"' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "install script keeps overlay lowerdir mounted" grep -q omarchy-mac-overlay-write \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
@@ -113,7 +115,13 @@ check "session file is looked up in usr/local/share" grep -q \
 check "graphical payload is required before wipefs" \
   bash -c 'awk "/^install_persistent_root\\(\\)/,/wipefs/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q require_graphical_payload'
 check "desktop user is asked before the payload copy" \
-  bash -c 'awk "/^install_persistent_root\\(\\)/,/copying payload/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q ask_desktop_user'
+  bash -c 'awk "/^install_persistent_root\\(\\)/,/copy_live_payload/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q ask_desktop_user'
+check "wipe-USB copies the live tree" \
+  bash -c 'awk "/^install_persistent_root\\(\\)/,/^apply_system_esp_bootloader/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q copy_live_payload'
+check "wipe-USB does not dd the live payload" \
+  bash -c '! awk "/^install_persistent_root\\(\\)/,/^apply_system_esp_bootloader/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q "dd if="'
+check "wipe-USB sizes the copy from used files" \
+  bash -c 'awk "/^install_persistent_root\\(\\)/,/^apply_system_esp_bootloader/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q live_payload_used_bytes'
 check "install initrd can come from a wipe-installed USB ESP" grep -q \
   'initramfs-omarchy-usb-root.img ]]; then' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
@@ -122,6 +130,12 @@ check "installed root uses graphical.target" grep -q 'set-default graphical.targ
 check "installed root creates a desktop user on @home" grep -q 'subvol=@home' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "installed root seeds Tokyo Night" grep -q 'omarchy-theme-set "Tokyo Night"' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "theme seed locks under /tmp in the chroot" grep -q 'XDG_RUNTIME_DIR=/tmp' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "payload copy skips pacman gnupg sockets" grep -q "exclude='./etc/pacman.d/gnupg/S.*'" \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "payload copy does not warn about ignored sockets" grep -q -- --warning=no-file-ignored \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "installed USB GRUB uses quiet splash" grep -q 'loglevel=3 quiet splash' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
@@ -135,6 +149,12 @@ check "install script offers free-space install" grep -q 'Install into free spac
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "free-space install does not wipefs" \
   bash -c 'awk "/^install_into_free_space\\(\\)/,/^action=/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -qv wipefs'
+check "free-space copies the live tree" \
+  bash -c 'awk "/^install_into_free_space\\(\\)/,/^existing_root_row/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q copy_live_payload'
+check "free-space does not dd the live payload" \
+  bash -c '! awk "/^install_into_free_space\\(\\)/,/^existing_root_row/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q "dd if="'
+check "free-space sizes the copy from used files" \
+  bash -c 'awk "/^install_into_free_space\\(\\)/,/^existing_root_row/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q live_payload_used_bytes'
 check "install script offers reinstall existing Omarchy root" grep -q \
   'Reinstall an existing Omarchy root' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
@@ -143,16 +163,41 @@ check "reinstall picker names the partition first" grep -q 'existing_root_row' \
 check "reinstall picker distinguishes internal NVMe from USB" grep -q \
   'internal NVMe' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
-check "live GRUB quiets console kmsg" grep -q 'loglevel=3 quiet' \
+check "live GRUB quiets console kmsg" grep -q 'quiet loglevel=0' \
   "${repo_root}/configs/usb/grub.cfg"
+check "live GRUB hides systemd boot status" grep -q 'systemd.show_status=0' \
+  "${repo_root}/configs/usb/grub.cfg"
+check "live GRUB hides systemd status in the initrd" grep -q 'rd.systemd.show_status=0' \
+  "${repo_root}/configs/usb/grub.cfg"
+check "live GRUB masks plymouth on the installer USB" grep -q \
+  'systemd.mask=plymouth-start.service' \
+  "${repo_root}/configs/usb/grub.cfg"
+check "refresh-live rebuilds the live initramfs" grep -q \
+  initramfs-omarchy-usb.img \
+  "${repo_root}/bin/omarchy-mac-iso-refresh-live"
+check "live hook quiets printk before switch_root" grep -q 'dmesg -n 1' \
+  "${repo_root}/configs/usb-initcpio/hooks/omarchy-usb-live"
+check "live rootfs hides systemd boot status" grep -q 'ShowStatus=no' \
+  "${repo_root}/configs/usb/rootfs/systemd-show-status.conf"
+check "refresh-live copies the systemd quiet drop-in" grep -q \
+  'system.conf.d/show-status.conf' \
+  "${repo_root}/bin/omarchy-mac-iso-refresh-live"
+check "live rootfs quiets firmware printk" grep -q 'kernel.printk' \
+  "${repo_root}/configs/usb/rootfs/sysctl-quiet-console.conf"
 check "replace existing root does not mkpart or mklabel" \
   bash -c '! awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -qE "wipefs -a|mklabel gpt|[[:space:]]mkpart root"'
-check "replace existing root asks the desktop user before dd" \
-  bash -c 'awk "/^install_over_existing_root\\(\\)/,/copying payload/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q ask_desktop_user'
+check "replace existing root asks the desktop user before copy" \
+  bash -c 'awk "/^install_over_existing_root\\(\\)/,/copy_live_payload/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q ask_desktop_user'
+check "replace existing copies the live tree" \
+  bash -c 'awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q copy_live_payload'
+check "replace existing does not dd the live payload" \
+  bash -c '! awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q "dd if="'
+check "replace existing sizes the copy from used files" \
+  bash -c 'awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q live_payload_used_bytes'
 check "replace existing root refuses the live payload" grep -q \
   'refusing to overwrite the live payload' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
-check "replace existing root checks Apple types after dd" \
+check "replace existing root checks Apple types after format" \
   bash -c 'awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q before_apple'
 check "sh -n omarchy-mac-disk.sh" bash -n \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-disk.sh"
@@ -179,6 +224,33 @@ check "install menu prints the Omarchy wordmark" grep -q logo.txt \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "live welcome execs the installer" grep -q 'exec omarchy-mac-install' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-live-welcome"
+check "install asks for a hostname" grep -q ask_hostname \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "hostname defaults to omarchy" grep -q 'desktop_hostname=omarchy' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "install reviews every choice before copying" grep -q 'Does this look right?' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "choice review can change user and encryption" grep -q 'No, change it' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "wipe-USB reviews choices before copy" \
+  bash -c 'awk "/^install_persistent_root\\(\\)/,/copy_live_payload/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q confirm_install_choices'
+check "free-space reviews choices before copy" \
+  bash -c 'awk "/^install_into_free_space\\(\\)/,/copy_live_payload/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q confirm_install_choices'
+check "replace existing reviews choices before copy" \
+  bash -c 'awk "/^install_over_existing_root\\(\\)/,/copy_live_payload/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q confirm_install_choices'
+check "password mismatch re-prompts instead of exiting" \
+  bash -c '! awk "/^ask_desktop_user\\(\\)/,/^ask_hostname/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q "fail \"passwords do not match\""'
+check "username validation re-prompts instead of exiting" \
+  bash -c '! awk "/^ask_desktop_user\\(\\)/,/^ask_hostname/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q "fail \"invalid username\""'
+check "hostname validation re-prompts instead of exiting" \
+  bash -c '! awk "/^ask_hostname\\(\\)/,/^write_installed_hostname/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q "fail \"hostname"'
+check "quiet console service runs before udev" grep -q 'Before=sysinit.target systemd-udevd.service' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-quiet-console.service"
+check "refresh-live enables the quiet console service" grep -q \
+  'enable omarchy-mac-quiet-console.service' \
+  "${repo_root}/bin/omarchy-mac-iso-refresh-live"
+check "install initrd ships asahi-notch.conf" grep -q asahi-notch.conf \
+  "${repo_root}/configs/usb-initcpio/install/omarchy-usb-wait"
 check "rootfs installs live welcome on tty1 autologin" grep -q omarchy-mac-live-welcome \
   "${repo_root}/builder/build-rootfs.sh"
 check "root bash_profile only runs welcome on tty1" grep -q '/dev/tty1' \
@@ -207,10 +279,25 @@ check "wipe-USB install can luksFormat" grep -q 'cryptsetup luksFormat' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "wipe-USB GRUB can pass cryptdevice" grep -q 'cryptdevice=UUID=' \
   "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
-check "free-space install does not luksFormat" \
-  bash -c '! awk "/^install_into_free_space\\(\\)/,/^install_over_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q luksFormat'
-check "replace existing root does not luksFormat" \
-  bash -c '! awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q luksFormat'
+check "free-space install can luksFormat" \
+  bash -c 'awk "/^install_into_free_space\\(\\)/,/^existing_root_row/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q luksFormat'
+check "free-space GRUB can pass cryptdevice" grep -q root_linux_args \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
+check "replace existing root can luksFormat" \
+  bash -c 'awk "/^install_over_existing_root\\(\\)/,/^install_grub_for_existing_root/" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-install" | grep -q luksFormat'
+check "LUKS containers are labelled OMARCHYROOT" grep -q 'luksFormat --type luks2 --label OMARCHYROOT' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
+check "replace existing finds an encrypted Omarchy root" grep -q 'fstype == crypto_LUKS' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
+check "encrypted Omarchy root is GPT name root or LUKS label" grep -q 'partlabel == root' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
+check "root probe does not combine lsblk --list and --pairs" \
+  bash -c '! grep -qE "lsblk -ln -P|lsblk -l -P" "'"${repo_root}"'/configs/usb/rootfs/omarchy-mac-esp.sh"'
+check "root probe uses lsblk --pairs without --list" grep -q 'lsblk -n -P -o NAME,FSTYPE,LABEL,PARTLABEL' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-esp.sh"
+check "replace existing says when no Omarchy root exists" grep -q \
+  'no existing Omarchy root found' \
+  "${repo_root}/configs/usb/rootfs/omarchy-mac-install"
 check "rootfs extra packages include cryptsetup" grep -qx cryptsetup \
   "${repo_root}/configs/usb/rootfs/packages"
 check "install initramfs lists dwc3_apple" grep -q dwc3_apple \


### PR DESCRIPTION
Wipe, free-space, and replace now format a fresh btrfs and copy used files from the live tree instead of `dd` of the 8GiB payload. Clone is still a whole-stick copy. LUKS is offered on all three install paths (same password as the desktop user), with a hostname prompt and a choice table before the copy.

Replace-existing can see an encrypted Omarchy root (LUKS labelled OMARCHYROOT or GPT name root) and does not offer Asahi's own disk. Live boot is quieter; `refresh-live` rebuilds both initrds. Metal: ~3.5G onto an encrypted NVMe hole in 1m 45s, SDDM autologin.